### PR TITLE
Adding Interested Button Database Functionality

### DIFF
--- a/volunta/components/EventCard.js
+++ b/volunta/components/EventCard.js
@@ -9,10 +9,7 @@ export default class EventCard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      interested: props.interested,
-      loaded: false,
-      org_name: '',
-      event: props.event
+      org_name: ''
     };
   }
 
@@ -33,21 +30,15 @@ export default class EventCard extends React.Component {
     return 40;
   };
 
-  // Sets state to interested/notInterested (user triggered)
-  _changeInterested = () => {
-    this.setState({
-      interested: !this.state.interested
-    });
-  };
-
+  // TODO: add date
   render() {
-    // const { navigate } = this.props.navigation;
-    const event = this.state.event;
+    const { event, interested, onPress, onClickInterested } = this.props;
+    const { org_name } = this.state;
     return (
       <View style={styles.shadow}>
         <TouchableOpacity
           style={styles.cardContainer}
-          onPress={() => this.props.onPress(event)}
+          onPress={() => onPress(event)}
         >
           <View style={styles.shadow}>
             <AsyncImage
@@ -62,14 +53,16 @@ export default class EventCard extends React.Component {
               name="star-circle-outline"
               size={45}
               style={styles.interestedIcon}
-              onPress={this._changeInterested}
-              color={this.state.interested ? '#0081AF' : 'grey'}
+              onPress={() => onClickInterested(event.doc_id)}
+              color={interested ? '#0081AF' : 'grey'}
             />
 
             <View style={styles.textContainer}>
               <View style={styles.titleTextContainer}>
                 <Text style={styles.titleText}>{event.title}</Text>
-                <Text style={styles.detailText}>{this.state.org_name}</Text>
+                <Text style={styles.detailText} numberOfLines={1}>
+                  {org_name}
+                </Text>
               </View>
               <View style={styles.detailTextContainer}>
                 <Text style={styles.detailText}>{event.date}</Text>

--- a/volunta/components/EventCard.js
+++ b/volunta/components/EventCard.js
@@ -9,14 +9,14 @@ export default class EventCard extends React.Component {
   constructor(props) {
     super(props);
     this.state = {
-      org_name: ''
+      org_name: '',
     };
   }
 
   // Fetch data here
   async componentWillMount() {
     this.setState({
-      org_name: await getOrganizationName(this.props.event.org_ref)
+      org_name: await getOrganizationName(this.props.event.org_ref),
     });
   }
 
@@ -44,7 +44,7 @@ export default class EventCard extends React.Component {
             <AsyncImage
               viewStyle={styles.coverPhoto}
               source={{
-                uri: event.cover_url
+                uri: event.cover_url,
               }}
               placeholderColor="#E8E8E8"
             />
@@ -59,7 +59,9 @@ export default class EventCard extends React.Component {
 
             <View style={styles.textContainer}>
               <View style={styles.titleTextContainer}>
-                <Text style={styles.titleText}>{event.title}</Text>
+                <Text numberOfLines={2} style={styles.titleText}>
+                  {event.title}
+                </Text>
                 <Text style={styles.detailText} numberOfLines={1}>
                   {org_name}
                 </Text>
@@ -87,56 +89,56 @@ const styles = StyleSheet.create({
     borderRadius: 20,
     overflow: 'hidden',
     marginBottom: 16,
-    marginLeft: 17
+    marginLeft: 17,
   },
   coverPhoto: {
     height: '50%',
     width: '100%',
     borderTopLeftRadius: 20,
-    borderTopRightRadius: 20
+    borderTopRightRadius: 20,
   },
   shadow: {
     flex: 1,
     shadowColor: 'black',
     shadowOffset: {
       width: 0,
-      height: 5
+      height: 5,
     },
     shadowOpacity: 0.25,
     shadowRadius: 3.84,
-    backgroundColor: '#0000' // invisible color
+    backgroundColor: '#0000', // invisible color
   },
   titleText: {
     fontFamily: 'montserrat',
     fontSize: 20,
     fontWeight: 'normal',
-    paddingBottom: 5
+    paddingBottom: 5,
   },
   detailText: {
     fontFamily: 'montserrat',
     fontSize: 14,
     fontWeight: 'normal',
-    color: '#838383'
+    color: '#838383',
   },
   textContainer: {
     flex: 1,
     flexDirection: 'row',
-    justifyContent: 'flex-start'
+    justifyContent: 'flex-start',
   },
   titleTextContainer: {
     flex: 3,
     justifyContent: 'center',
-    paddingLeft: 13
+    paddingLeft: 13,
   },
   detailTextContainer: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'flex-end',
-    paddingRight: 13
+    paddingRight: 13,
   },
   interestedIcon: {
     position: 'absolute',
     left: EventCardConstants.cardWidth - 45,
-    bottom: EventCardConstants.cardHeight / 2
-  }
+    bottom: EventCardConstants.cardHeight / 2,
+  },
 });

--- a/volunta/firebase/api.js
+++ b/volunta/firebase/api.js
@@ -89,7 +89,7 @@ export const getAllUserInterestedEventsDocIds = async userDocId => {
     .doc(userDocId)
     .get()
     .then(snapshot => {
-      interested_refs = snapshot.get('event_refs.interested');
+      let interested_refs = snapshot.get('event_refs.interested');
       interested_refs.forEach(ref => interested.add(ref.id));
     })
     .catch(error => {

--- a/volunta/firebase/api.js
+++ b/volunta/firebase/api.js
@@ -45,12 +45,12 @@ export const getEventsForCommunity = async () => {
         if (eventFromDate > currentDate) {
           data.status = 'upcoming';
           returnArrUpcoming.push(data);
-        // An event is in the past if event to_date is less than current date
+          // An event is in the past if event to_date is less than current date
         } else if (eventEndDate < currentDate) {
           data.status = 'past';
           returnArrPast.push(data);
-        // This means that from_date <= current date and to_date >= current date,
-        // so the event is currently ongoing
+          // This means that from_date <= current date and to_date >= current date,
+          // so the event is currently ongoing
         } else {
           data.status = 'ongoing';
           returnArrOngoing.push(data);
@@ -89,12 +89,47 @@ export const getAllUserInterestedEventsDocIds = async userDocId => {
     .doc(userDocId)
     .get()
     .then(snapshot => {
-      interested_refs = snapshot.get('event_refs.going');
+      interested_refs = snapshot.get('event_refs.interested');
+      interested_refs.forEach(ref => interested.add(ref.id));
     })
     .catch(error => {
       console.log(error);
       return null;
     });
-  interested_refs.forEach(ref => interested.add(ref.id));
   return interested;
+};
+
+// Update list of events that user is interested on
+// add: boolean specifying if we want to add (true) or remove (false) the eventId from the userId's iterested events list.
+// Returns true if success otherwise false
+// We use a transaction since we both get and update.
+// TODO: make sure we return false in case there is a connection error, this is currently not working. Not sure how to verify if the transaction was successful!! Currently the .catch is never reached..
+export const updateUserInterestedEvents = async (userId, eventId, add) => {
+  const userRef = await firestore.collection('users').doc(userId);
+  const eventToUpdateRef = await firestore.collection('events').doc(eventId);
+  await firestore
+    .runTransaction(async transaction => {
+      const userDoc = await transaction.get(userRef);
+      let events = await userDoc.get('event_refs.interested');
+      if (add) {
+        events.push(eventToUpdateRef); // Simply push the new eventRef
+      } else {
+        // Make set of all current ids except the one we are removing (probably do not want to check for reference inclusion) since reference objects are large.
+        // We use a set to make sure there are no duplicates.
+        updatedSet = new Set();
+        events.forEach(eventRef => {
+          if (eventRef.id !== eventId) updatedSet.add(eventRef.id);
+        });
+        events = new Array();
+        updatedSet.forEach(eventId => {
+          events.push(firestore.collection('events').doc(eventId));
+        });
+      }
+      transaction.update(userRef, 'event_refs.interested', events);
+    })
+    .catch(error => {
+      console.log(error);
+      return false;
+    });
+  return true;
 };

--- a/volunta/firebase/apiKey.js
+++ b/volunta/firebase/apiKey.js
@@ -1,1 +1,0 @@
-export const FIREBASE_API_KEY = '<FIREBASE_WEB_API_KEY>';

--- a/volunta/firebase/firebase.js
+++ b/volunta/firebase/firebase.js
@@ -1,11 +1,11 @@
 import * as firebase from 'firebase';
 import 'firebase/firestore';
 import * as c from './fb_constants';
-import FIREBASE_API_KEY from './apiKey';
+// import FIREBASE_API_KEY from './apiKey';
 
 // Initialize Firebase
 const config = {
-  apiKey: FIREBASE_API_KEY,
+  // apiKey: FIREBASE_API_KEY,
   projectId: c.FIREBASE_PROJECT_ID,
   databaseURL: c.FIREBASE_DATABASE_URL
 };

--- a/volunta/screens/FeedScreen.js
+++ b/volunta/screens/FeedScreen.js
@@ -2,7 +2,11 @@ import React from 'react';
 import { StyleSheet, FlatList, View, Dimensions } from 'react-native';
 import { EventCard } from '../components';
 import { SearchBar } from 'react-native-elements';
-import { getEvents, getAllUserInterestedEventsDocIds } from '../firebase/api';
+import {
+  getEvents,
+  getAllUserInterestedEventsDocIds,
+  updateUserInterestedEvents
+} from '../firebase/api';
 
 export default class FeedScreen extends React.Component {
   constructor(props) {
@@ -11,7 +15,9 @@ export default class FeedScreen extends React.Component {
       events: [],
       isRefreshing: false,
       search: '',
-      interestedEventDocIds: new Set()
+      interestedEventDocIds: new Set(), // IDs of all events that user is interested on
+      userId: 'kgxbnXxwNXKIupPuIrcV', // TODO: pass in as prop
+      interestedMap: new Map() // <string, boolean>, tells us if user is interested in eventid
     };
   }
 
@@ -20,28 +26,41 @@ export default class FeedScreen extends React.Component {
     this._loadData();
   }
 
+  componentWillUnmount() {
+    // TODO: Cancel async calls to prevent memory leakage (look into this later..)
+  }
+
   // Load data needed for the screen and its components
   // 1) Detch list of events using api call.
   // 2) Retrieve all events the user is interested in for the interested prop in EventCard
   // TODO: Using hard coded user doc id, make that a constant for now...
+  // TODO: show error message in case fetching goes wrong (if anything returns null or error?)...
   _loadData = async () => {
     this.setState({
       isRefreshing: true // Needed for FlatList to know
     });
+
+    // Fetch all event objects into array and initialize interestedMap to all false
     const events = await getEvents();
-    const interestedEventDocIds = await getAllUserInterestedEventsDocIds(
-      'kgxbnXxwNXKIupPuIrcV'
-    );
+
+    let interestedMap = new Map();
+
+    // Fetch event doc ids that user is interested on and set them to true in the map
+    await getAllUserInterestedEventsDocIds(
+      this.state.userId // TODO: make user id a prop
+    ).then(event_doc_ids => {
+      event_doc_ids.forEach(event_doc_id => {
+        interestedMap.set(event_doc_id, true);
+      });
+    });
+
+    // Update state and restore refreshing
     this.setState({
-      isRefreshing: false, // Restore
+      isRefreshing: false,
       events,
-      interestedEventDocIds
+      interestedMap
     });
   };
-
-  componentWillUnmount() {
-    // TODO: Cancel async calls to prevent memory leakage
-  }
 
   // Called when user types something into search bar.
   // Right now simply update displayed text.
@@ -49,22 +68,55 @@ export default class FeedScreen extends React.Component {
     this.setState({ search });
   };
 
-  // Function we pass to EventCard, pushes screen onto feed stack with the corresponding event page
+  // Function we pass to EventCard, pushes screen onto current stack with the corresponding event page
   _onPressEventCard = event => {
     this.props.navigation.push('Event', {
       event
     });
   };
 
+  // Not explicit used now but will potentially be.
+  _keyExtractor = (item, index) => item.doc_id;
+
   // Render card. The 'item' is an event object. Must be named item for function to work.
   _renderEventCard = ({ item }) => {
     return (
       <EventCard
+        id={item.doc_id}
         event={item}
         onPress={this._onPressEventCard}
-        interested={this.state.interestedEventDocIds.has(item.doc_id)}
+        interested={!!this.state.interestedMap.get(item.doc_id)}
+        onClickInterested={this._updateInterested}
       />
     );
+  };
+
+  // Function that we pass to the child (EventCard) that should be called when user presses the 'interested' button.
+  // We first get try updating the state in the FE.
+  // Then we try updating in the database. If the update fails we toggle it back.
+  // Otherwise we toggle
+  _updateInterested = async eventId => {
+    // copy the map rather than modifying state
+    const interestedMap = new Map(this.state.interestedMap);
+
+    // Toggle button in FE
+    interestedMap.set(eventId, !interestedMap.get(eventId));
+    this.setState({ interestedMap });
+
+    // Try to update in database.
+    interested = !this.state.interestedMap.get(eventId);
+    success = await updateUserInterestedEvents(
+      this.state.userId,
+      eventId,
+      interested
+    );
+    console.log(success);
+
+    // Toggle back if database update failed.
+    if (!success) {
+      interestedMap.set(eventId, !interestedMap.get(eventId));
+      this.setState({ interestedMap });
+    }
   };
 
   render() {
@@ -85,8 +137,9 @@ export default class FeedScreen extends React.Component {
             style={styles.flatListStyle}
             renderItem={this._renderEventCard}
             data={events}
+            extraData={this.state} // Needed for child to update when 'interested' changes
             onRefresh={() => this._loadData()}
-            keyExtractor={(_, index) => index.toString()}
+            keyExtractor={this._keyExtractor}
             refreshing={isRefreshing}
           />
         )}
@@ -97,7 +150,7 @@ export default class FeedScreen extends React.Component {
 
 const styles = StyleSheet.create({
   pageContainer: {
-    width: Dimensions.get('window').width,
+    width: Dimensions.get('window').width
   },
   searchContainerStyle: {
     backgroundColor: 'white',
@@ -105,13 +158,13 @@ const styles = StyleSheet.create({
     shadowColor: 'white', //no effect
     borderBottomColor: 'transparent',
     borderTopColor: 'transparent',
-    width:'95%',
+    width: '95%',
     alignSelf: 'center'
   },
   searchInputContainerStyle: {
     backgroundColor: '#E8E8E8'
   },
   flatListStyle: {
-    height: '100%',
+    height: '100%'
   }
 });

--- a/volunta/screens/FeedScreen.js
+++ b/volunta/screens/FeedScreen.js
@@ -5,7 +5,7 @@ import { SearchBar } from 'react-native-elements';
 import {
   getEvents,
   getAllUserInterestedEventsDocIds,
-  updateUserInterestedEvents
+  updateUserInterestedEvents,
 } from '../firebase/api';
 
 export default class FeedScreen extends React.Component {
@@ -17,7 +17,7 @@ export default class FeedScreen extends React.Component {
       search: '',
       interestedEventDocIds: new Set(), // IDs of all events that user is interested on
       userId: 'kgxbnXxwNXKIupPuIrcV', // TODO: pass in as prop
-      interestedMap: new Map() // <string, boolean>, tells us if user is interested in eventid
+      interestedMap: new Map(), // <string, boolean>, tells us if user is interested in eventid
     };
   }
 
@@ -37,7 +37,7 @@ export default class FeedScreen extends React.Component {
   // TODO: show error message in case fetching goes wrong (if anything returns null or error?)...
   _loadData = async () => {
     this.setState({
-      isRefreshing: true // Needed for FlatList to know
+      isRefreshing: true, // Needed for FlatList to know
     });
 
     // Fetch all event objects into array and initialize interestedMap to all false
@@ -58,7 +58,7 @@ export default class FeedScreen extends React.Component {
     this.setState({
       isRefreshing: false,
       events,
-      interestedMap
+      interestedMap,
     });
   };
 
@@ -71,7 +71,7 @@ export default class FeedScreen extends React.Component {
   // Function we pass to EventCard, pushes screen onto current stack with the corresponding event page
   _onPressEventCard = event => {
     this.props.navigation.push('Event', {
-      event
+      event,
     });
   };
 
@@ -85,14 +85,14 @@ export default class FeedScreen extends React.Component {
         id={item.doc_id}
         event={item}
         onPress={this._onPressEventCard}
-        interested={!!this.state.interestedMap.get(item.doc_id)}
+        interested={this.state.interestedMap.get(item.doc_id)}
         onClickInterested={this._updateInterested}
       />
     );
   };
 
   // Function that we pass to the child (EventCard) that should be called when user presses the 'interested' button.
-  // We first get try updating the state in the FE.
+  // We first get try updating the state in the Front End.
   // Then we try updating in the database. If the update fails we toggle it back.
   // Otherwise we toggle
   _updateInterested = async eventId => {
@@ -110,7 +110,6 @@ export default class FeedScreen extends React.Component {
       eventId,
       interested
     );
-    console.log(success);
 
     // Toggle back if database update failed.
     if (!success) {
@@ -150,7 +149,7 @@ export default class FeedScreen extends React.Component {
 
 const styles = StyleSheet.create({
   pageContainer: {
-    width: Dimensions.get('window').width
+    width: Dimensions.get('window').width,
   },
   searchContainerStyle: {
     backgroundColor: 'white',
@@ -159,12 +158,12 @@ const styles = StyleSheet.create({
     borderBottomColor: 'transparent',
     borderTopColor: 'transparent',
     width: '95%',
-    alignSelf: 'center'
+    alignSelf: 'center',
   },
   searchInputContainerStyle: {
-    backgroundColor: '#E8E8E8'
+    backgroundColor: '#E8E8E8',
   },
   flatListStyle: {
-    height: '100%'
-  }
+    height: '100%',
+  },
 });


### PR DESCRIPTION
Modified FeedScreen and EventCard so that FeedScreen controls all the functionality for the interested button and EventCard simply calls a function from FeedScreen. This way the EventCard component has all info it needs from the props. This made it easier to update the database.

For updating the database, we either add an item to the list of interested events or remove the event from the list. When removing, we use a set to make sure that there are no duplicate entries. 

The idea also is that the API call returns false in case it fails so that the FeedScreen tells the EventCard that the call failed and it can toggle back the interested button to its original state (this is how FB does it). But I have not been able to figure out how to know if a transaction fails.  

Fixes #23 