### PR TITLE
Pull-down refresh on community / profile screens

### DIFF
--- a/volunta/components/CommunityCoverPhoto.js
+++ b/volunta/components/CommunityCoverPhoto.js
@@ -48,7 +48,7 @@ const styles = StyleSheet.create({
   },
   titleText: {
     height: 36,
-    bottom: 84,
+    bottom: 100,
     fontSize: 24,
     color: 'white',
     fontFamily: 'montserrat',

--- a/volunta/screens/CommunityScreen.js
+++ b/volunta/screens/CommunityScreen.js
@@ -1,5 +1,11 @@
 import React from 'react';
-import { StyleSheet, View, Text } from 'react-native';
+import {
+  StyleSheet,
+  View,
+  Text,
+  ScrollView,
+  RefreshControl,
+} from 'react-native';
 import Facepile from '../components/Facepile';
 import CommunityCoverPhoto from '../components/CommunityCoverPhoto';
 import CommunityProfileEventCardHorizontalScroll from '../components/CommunityProfileEventCardHorizontalScroll';
@@ -21,6 +27,7 @@ export default class CommunityScreen extends React.Component {
       communityPhoto: '',
       communityName: '',
       interestedEventDocIds: new Set(),
+      refreshing: false,
     };
   }
 
@@ -29,6 +36,10 @@ export default class CommunityScreen extends React.Component {
   }
 
   _loadData = async () => {
+    this.setState({
+      refreshing: true,
+    });
+
     // Get event data
     const [
       upcomingEvents,
@@ -54,6 +65,7 @@ export default class CommunityScreen extends React.Component {
       communityPhoto,
       communityName,
       interestedEventDocIds,
+      refreshing: false,
     });
   };
 
@@ -64,40 +76,51 @@ export default class CommunityScreen extends React.Component {
       communityPhoto,
       communityName,
       interestedEventDocIds,
+      refreshing,
     } = this.state;
 
     return (
-      <View>
-        <CommunityCoverPhoto
-          communityPhoto={communityPhoto}
-          communityName={communityName}
-        />
-        <View style={styles.topText}>
-          <Text style={styles.titleText}>{'in my community'}</Text>
-        </View>
-        <View style={styles.facepileContainer}>
-          <Facepile totalWidth={335} maxNumImages={10} imageDiameter={50} />
-        </View>
-
-        <View style={styles.middleText}>
-          <Text style={styles.titleText}>{'coming up'}</Text>
-        </View>
-        <View style={styles.upcomingScroll}>
-          <CommunityProfileEventCardHorizontalScroll
-            events={upcomingEvents}
-            interestedIDs={interestedEventDocIds}
+      // Invisible ScrollView component to add pull-down refresh functionality
+      <ScrollView
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => this._loadData()}
           />
-        </View>
-        <View style={styles.bottomText}>
-          <Text style={styles.titleText}>{"how we've helped"}</Text>
-          <View style={styles.pastScroll}>
+        }
+      >
+        <View>
+          <CommunityCoverPhoto
+            communityPhoto={communityPhoto}
+            communityName={communityName}
+          />
+          <View style={styles.topText}>
+            <Text style={styles.titleText}>{'in my community'}</Text>
+          </View>
+          <View style={styles.facepileContainer}>
+            <Facepile totalWidth={335} maxNumImages={10} imageDiameter={50} />
+          </View>
+
+          <View style={styles.middleText}>
+            <Text style={styles.titleText}>{'coming up'}</Text>
+          </View>
+          <View style={styles.upcomingScroll}>
             <CommunityProfileEventCardHorizontalScroll
-              events={pastEvents}
+              events={upcomingEvents}
               interestedIDs={interestedEventDocIds}
             />
           </View>
+          <View style={styles.bottomText}>
+            <Text style={styles.titleText}>{"how we've helped"}</Text>
+            <View style={styles.pastScroll}>
+              <CommunityProfileEventCardHorizontalScroll
+                events={pastEvents}
+                interestedIDs={interestedEventDocIds}
+              />
+            </View>
+          </View>
         </View>
-      </View>
+      </ScrollView>
     );
   }
 }
@@ -110,17 +133,17 @@ const styles = StyleSheet.create({
     left: 19,
   },
   topText: {
-    top: -44,
+    top: -85,
   },
   facepileContainer: {
     left: 19,
-    top: -42,
+    top: -80,
   },
   middleText: {
-    top: -30,
+    top: -65,
   },
   bottomText: {
-    top: -20,
+    top: -50,
   },
   placeholder: {
     width: 335,
@@ -131,10 +154,11 @@ const styles = StyleSheet.create({
   },
   upcomingScroll: {
     left: 15,
-    top: -25,
+    top: -60,
   },
   pastScroll: {
     left: 15,
     top: 7,
+    height: 0, //removes extra blank space at bottom of scroll
   },
 });

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -1,5 +1,13 @@
 import React from 'react';
-import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import {
+  Image,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+  ScrollView,
+  RefreshControl,
+} from 'react-native';
 import Facepile from '../components/Facepile';
 import InterestBubble from '../components/InterestBubble';
 import CommunityProfileEventCardHorizontalScroll from '../components/CommunityProfileEventCardHorizontalScroll';
@@ -17,6 +25,7 @@ export default class ProfileScreen extends React.Component {
       upcomingEvents: [],
       pastEvents: [],
       interestedEventDocIds: new Set(),
+      refreshing: false,
     };
   }
 
@@ -26,6 +35,10 @@ export default class ProfileScreen extends React.Component {
 
   //TODO: change this to be profile-specific and consolidate profile/community logic in a shared space
   _loadData = async () => {
+    this.setState({
+      refreshing: true,
+    });
+
     const [
       upcomingEvents,
       pastEvents,
@@ -41,64 +54,80 @@ export default class ProfileScreen extends React.Component {
       upcomingEvents,
       pastEvents,
       interestedEventDocIds,
+      refreshing: false,
     });
   };
 
   render() {
-    const { upcomingEvents, pastEvents, interestedEventDocIds } = this.state;
+    const {
+      upcomingEvents,
+      pastEvents,
+      interestedEventDocIds,
+      refreshing,
+    } = this.state;
 
     return (
-      <View style={styles.container}>
-        <View style={styles.profileBar}>
-          <Image
-            style={styles.profilePic}
-            source={require('../assets/images/kanye.png')}
+      // Invisible ScrollView component to add pull-down refresh functionality
+      <ScrollView
+        refreshControl={
+          <RefreshControl
+            refreshing={refreshing}
+            onRefresh={() => this._loadData()}
           />
-          <View style={styles.upperText}>
-            <Text style={styles.personName}>Kanye West</Text>
-            <Text style={styles.communityName}>Stanford University</Text>
+        }
+      >
+        <View style={styles.container}>
+          <View style={styles.profileBar}>
+            <Image
+              style={styles.profilePic}
+              source={require('../assets/images/kanye.png')}
+            />
+            <View style={styles.upperText}>
+              <Text style={styles.personName}>Kanye West</Text>
+              <Text style={styles.communityName}>Stanford University</Text>
+            </View>
+            <TouchableOpacity style={styles.editIcon}>
+              <Feather name="edit" size={30} color="#0081AF" />
+            </TouchableOpacity>
           </View>
-          <TouchableOpacity style={styles.editIcon}>
-            <Feather name="edit" size={30} color="#0081AF" />
-          </TouchableOpacity>
-        </View>
-        <View style={styles.interestBar}>
-          <Text style={styles.sectionTitle}>interests:</Text>
-          <View style={styles.singleInterestRow}>
-            <InterestBubble interestName={'public health'} />
-            <InterestBubble interestName={'kitties'} />
-            <InterestBubble interestName={'social good'} />
+          <View style={styles.interestBar}>
+            <Text style={styles.sectionTitle}>interests:</Text>
+            <View style={styles.singleInterestRow}>
+              <InterestBubble interestName={'public health'} />
+              <InterestBubble interestName={'kitties'} />
+              <InterestBubble interestName={'social good'} />
+            </View>
+            <View style={styles.singleInterestRow}>
+              <InterestBubble interestName={'kids'} />
+              <InterestBubble interestName={'environmental'} />
+              <InterestBubble interestName={'civics'} />
+              <InterestBubble interestName={'...'} />
+            </View>
           </View>
-          <View style={styles.singleInterestRow}>
-            <InterestBubble interestName={'kids'} />
-            <InterestBubble interestName={'environmental'} />
-            <InterestBubble interestName={'civics'} />
-            <InterestBubble interestName={'...'} />
+          <View style={styles.comingUpBar}>
+            <Text style={styles.sectionTitle}>coming up:</Text>
+            <View style={styles.upcomingScroll}>
+              <CommunityProfileEventCardHorizontalScroll
+                events={upcomingEvents}
+                interestedIDs={interestedEventDocIds}
+              />
+            </View>
           </View>
-        </View>
-        <View style={styles.comingUpBar}>
-          <Text style={styles.sectionTitle}>coming up:</Text>
-          <View style={styles.upcomingScroll}>
+          <View style={styles.helpedBar}>
+            <Text style={styles.helpedTitle}>how I've helped:</Text>
             <CommunityProfileEventCardHorizontalScroll
-              events={upcomingEvents}
+              events={pastEvents}
               interestedIDs={interestedEventDocIds}
             />
           </View>
+          <View>
+            <Text style={styles.sectionTitle}>volunteer network:</Text>
+          </View>
+          <View style={styles.facepileContainer}>
+            <Facepile totalWidth={335} maxNumImages={10} imageDiameter={50} />
+          </View>
         </View>
-        <View style={styles.helpedBar}>
-          <Text style={styles.helpedTitle}>how I've helped:</Text>
-          <CommunityProfileEventCardHorizontalScroll
-            events={pastEvents}
-            interestedIDs={interestedEventDocIds}
-          />
-        </View>
-        <View>
-          <Text style={styles.sectionTitle}>volunteer network:</Text>
-        </View>
-        <View style={styles.facepileContainer}>
-          <Facepile totalWidth={335} maxNumImages={10} imageDiameter={50} />
-        </View>
-      </View>
+      </ScrollView>
     );
   }
 }


### PR DESCRIPTION
Built a ScrollView around the community and profile screens with refresh functionality so that event data (and eventually facepile data) is refreshed upon pull down. Tested this works by updating events in the database. Fixes #25 
Eventually I want to refactor the community screen stylesheets using flex so we don't have to change the top values when we add in components, but that's low priority for now.
![Simulator Screen Shot - iPhone X - 2019-05-03 at 16 20 30](https://user-images.githubusercontent.com/32403070/57170506-3b733600-6dc2-11e9-892a-7268da5b4e75.png)
![Simulator Screen Shot - iPhone X - 2019-05-03 at 16 20 33](https://user-images.githubusercontent.com/32403070/57170508-3b733600-6dc2-11e9-8a83-bee234705181.png)


