### PR TITLE
Connect entire event screen to database

### DIFF
--- a/volunta/components/CommunityProfileEventCard.js
+++ b/volunta/components/CommunityProfileEventCard.js
@@ -23,13 +23,14 @@ export default class CommunityProfileEventCard extends React.Component {
 
   render() {
     const { event, interested, onPress } = this.props;
+    const { date, org_name } = this.state;
     const upcoming = event.status == 'upcoming';
     return (
       <View style={styles.shadow}>
         {/* if the event is in the past list, make the height shorter */}
         <TouchableOpacity
           style={[styles.cardContainer, { height: upcoming ? 153 : 118 }]}
-          onPress={() => onPress(event)}
+          onPress={() => onPress(event, org_name, interested)}
         >
           <View style={styles.shadow}>
             <Image
@@ -42,7 +43,7 @@ export default class CommunityProfileEventCard extends React.Component {
                   {event.title}
                 </Text>
                 <Text style={styles.detailText} numberOfLines={1}>
-                  {this.state.org_name}
+                  {org_name}
                 </Text>
               </View>
               <View
@@ -52,7 +53,7 @@ export default class CommunityProfileEventCard extends React.Component {
                     : styles.smallDetailTextContainer
                 }
               >
-                <Text style={styles.dateText}>{this.state.date}</Text>
+                <Text style={styles.dateText}>{date}</Text>
                 <Icon
                   name={'star-circle-outline'}
                   size={23}

--- a/volunta/components/EventCard.js
+++ b/volunta/components/EventCard.js
@@ -41,7 +41,7 @@ export default class EventCard extends React.Component {
       <View style={styles.shadow}>
         <TouchableOpacity
           style={styles.cardContainer}
-          onPress={() => onPress(event)}
+          onPress={() => onPress(event, org_name, interested)}
         >
           <View style={styles.shadow}>
             <AsyncImage

--- a/volunta/components/EventPageAboutSection.js
+++ b/volunta/components/EventPageAboutSection.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Image, StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, Dimensions } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Colors from '../constants/Colors';
 import { timestampToDate, dateToWords, timestampToTimeOfDay } from '../utils';
@@ -20,6 +20,15 @@ export default class EventPageAboutSection extends React.Component {
     const dateFormatted = dateToWords(timestampToDate(fromDate));
     const timeFormatted =
       timestampToTimeOfDay(fromDate) + '  -  ' + timestampToTimeOfDay(toDate);
+    const addressFormatted =
+      location.street_addr +
+      ', ' +
+      location.city +
+      ', ' +
+      location.state +
+      ', ' +
+      location.zip_code;
+
     return (
       <View style={styles.divider}>
         <View style={styles.container}>
@@ -43,9 +52,7 @@ export default class EventPageAboutSection extends React.Component {
               style={styles.pin}
               color={Colors.aboutIconGray}
             />
-            <Text style={styles.aboutInfoText}>
-              {'450 Serra Mall, Stanford, CA 94305'}
-            </Text>
+            <Text style={styles.aboutInfoText}>{addressFormatted}</Text>
           </View>
         </View>
       </View>
@@ -70,7 +77,8 @@ const styles = StyleSheet.create({
   aboutInfo: {
     flexDirection: 'row',
     alignItems: 'center',
-    height: 30,
+    // height: 30,
+    width: Dimensions.get('window').width - 70,
   },
   aboutInfoText: {
     fontSize: 14,

--- a/volunta/components/EventPageAboutSection.js
+++ b/volunta/components/EventPageAboutSection.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Image, StyleSheet, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Colors from '../constants/Colors';
-import { timestampToDate, dateToWords } from '../utils';
+import { timestampToDate, dateToWords, timestampToTimeOfDay } from '../utils';
 
 /*
 This component displays as a section within a single event page to give 
@@ -16,9 +16,10 @@ Props:
 
 export default class EventPageAboutSection extends React.Component {
   render() {
-    //TODO: convert timestamp to string date / times and fill in info, hard-coded for now
     const { fromDate, toDate, location } = this.props;
     const dateFormatted = dateToWords(timestampToDate(fromDate));
+    const timeFormatted =
+      timestampToTimeOfDay(fromDate) + '  -  ' + timestampToTimeOfDay(toDate);
     return (
       <View style={styles.divider}>
         <View style={styles.container}>
@@ -33,7 +34,7 @@ export default class EventPageAboutSection extends React.Component {
           </View>
           <View style={styles.aboutInfo}>
             <Ionicons name="ios-clock" size={24} color={Colors.aboutIconGray} />
-            <Text style={styles.aboutInfoText}>{'6:30PM - 9:30PM'}</Text>
+            <Text style={styles.aboutInfoText}>{timeFormatted}</Text>
           </View>
           <View style={styles.aboutInfo}>
             <Ionicons

--- a/volunta/components/EventPageAboutSection.js
+++ b/volunta/components/EventPageAboutSection.js
@@ -77,7 +77,6 @@ const styles = StyleSheet.create({
   aboutInfo: {
     flexDirection: 'row',
     alignItems: 'center',
-    // height: 30,
     width: Dimensions.get('window').width - 70,
   },
   aboutInfoText: {

--- a/volunta/components/EventPageAboutSection.js
+++ b/volunta/components/EventPageAboutSection.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { Image, StyleSheet, Text, View } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Colors from '../constants/Colors';
+import { timestampToDate, dateToWords } from '../utils';
 
 /*
 This component displays as a section within a single event page to give 
@@ -17,6 +18,7 @@ export default class EventPageAboutSection extends React.Component {
   render() {
     //TODO: convert timestamp to string date / times and fill in info, hard-coded for now
     const { fromDate, toDate, location } = this.props;
+    const dateFormatted = dateToWords(timestampToDate(fromDate));
     return (
       <View style={styles.divider}>
         <View style={styles.container}>
@@ -27,7 +29,7 @@ export default class EventPageAboutSection extends React.Component {
               size={24}
               color={Colors.aboutIconGray}
             />
-            <Text style={styles.aboutInfoText}>{'June 20, 2019'}</Text>
+            <Text style={styles.aboutInfoText}>{dateFormatted}</Text>
           </View>
           <View style={styles.aboutInfo}>
             <Ionicons name="ios-clock" size={24} color={Colors.aboutIconGray} />

--- a/volunta/components/EventPageHeader.js
+++ b/volunta/components/EventPageHeader.js
@@ -12,7 +12,6 @@ Props:
 
 export default class EventPageHeader extends React.Component {
   render() {
-    console.log(this.props);
     const {
       eventTitle,
       organizationName,

--- a/volunta/components/SingleNotification.js
+++ b/volunta/components/SingleNotification.js
@@ -3,7 +3,9 @@ import { StyleSheet, Text, View, Image } from 'react-native';
 
 export default class SingleNotification extends React.Component {
   render() {
+    console.log(this.props);
     const { orgName, orgPhoto, message, timeAsStr } = this.props;
+    console.log(typeof orgPhoto);
     return (
       <View style={styles.box}>
         <Image style={styles.organizationPic} source={{ uri: orgPhoto }} />

--- a/volunta/components/SingleNotification.js
+++ b/volunta/components/SingleNotification.js
@@ -3,9 +3,7 @@ import { StyleSheet, Text, View, Image } from 'react-native';
 
 export default class SingleNotification extends React.Component {
   render() {
-    console.log(this.props);
     const { orgName, orgPhoto, message, timeAsStr } = this.props;
-    console.log(typeof orgPhoto);
     return (
       <View style={styles.box}>
         <Image style={styles.organizationPic} source={{ uri: orgPhoto }} />

--- a/volunta/components/SingleNotification.js
+++ b/volunta/components/SingleNotification.js
@@ -1,19 +1,12 @@
 import React from 'react';
-import {
-  StyleSheet,
-  Text,
-  View,
-  Image,
-} from 'react-native';
+import { StyleSheet, Text, View, Image } from 'react-native';
 
 export default class SingleNotification extends React.Component {
   render() {
-    console.log(this.props)
-    const {orgName, orgPhoto, message, timeAsStr} = this.props
-    console.log(typeof(orgPhoto))
+    const { orgName, orgPhoto, message, timeAsStr } = this.props;
     return (
       <View style={styles.box}>
-        <Image style={styles.organizationPic} source={{uri: orgPhoto}} />
+        <Image style={styles.organizationPic} source={{ uri: orgPhoto }} />
         <Text style={styles.organizationText}>{orgName}</Text>
         <Text style={styles.messageText}>{message}</Text>
         <Text style={styles.timeText}>{timeAsStr}</Text>
@@ -23,39 +16,39 @@ export default class SingleNotification extends React.Component {
 }
 
 const styles = StyleSheet.create({
-    box: {
-        backgroundColor:'#EEEEEE',
-        height: 90,
-        marginBottom: 10,
-    },
-    organizationPic: {
-        height: 60,
-        width: 60,
-        marginLeft: 15, 
-        marginTop: 12,
-        borderRadius: 30,
-        position: 'absolute',
-    },
-    organizationText: {
-        marginTop: 18,
-        marginLeft: 85,
-        fontSize: 16,
-        fontWeight: '600',
-        marginBottom: 4
-    },
-    messageText: {
-        marginLeft: 85,
-        width: 225,
-        color: 'black',
-        fontFamily: 'montserrat',
-        fontSize: 12
-    },
-    timeText: {
-        color: 'black',
-        fontFamily: 'montserrat',
-        fontSize: 14,
-        position: 'absolute',
-        marginTop: 35,
-        marginLeft: 325
-    }
+  box: {
+    backgroundColor: '#EEEEEE',
+    height: 90,
+    marginBottom: 10,
+  },
+  organizationPic: {
+    height: 60,
+    width: 60,
+    marginLeft: 15,
+    marginTop: 12,
+    borderRadius: 30,
+    position: 'absolute',
+  },
+  organizationText: {
+    marginTop: 18,
+    marginLeft: 85,
+    fontSize: 16,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  messageText: {
+    marginLeft: 85,
+    width: 225,
+    color: 'black',
+    fontFamily: 'montserrat',
+    fontSize: 12,
+  },
+  timeText: {
+    color: 'black',
+    fontFamily: 'montserrat',
+    fontSize: 14,
+    position: 'absolute',
+    marginTop: 35,
+    marginLeft: 325,
+  },
 });

--- a/volunta/firebase/api.js
+++ b/volunta/firebase/api.js
@@ -251,7 +251,7 @@ export const getNumGoingForAllEvents = async () => {
   return counts;
 };
 
-// Returns a DefaultDict that maps from each eventDocID to a Set of user ids going
+// Returns a DefaultDict that maps from each eventDocID to an array of user ids going
 export const getUsersGoingForAllEvents = async () => {
   var attendees = {};
   var usersRef = firestore.collection('users');
@@ -277,4 +277,24 @@ export const getUsersGoingForAllEvents = async () => {
       return null;
     });
   return attendees;
+};
+
+// Takes in reference to a community object, such as the output of getUserCommunity
+// Returns a list of user ids of members in the specified community
+export const getCommunityMemberUserIds = async communityRef => {
+  var communityMembers = [];
+  var usersRef = firestore.collection('users');
+  await usersRef
+    .where('community_ref', '==', communityRef)
+    .get()
+    .then(snapshot => {
+      snapshot.forEach(userDoc => {
+        communityMembers.push(userDoc.id);
+      });
+    })
+    .catch(error => {
+      console.log(error);
+      return null;
+    });
+  return communityMembers;
 };

--- a/volunta/firebase/api.js
+++ b/volunta/firebase/api.js
@@ -250,3 +250,31 @@ export const getNumGoingForAllEvents = async () => {
     });
   return counts;
 };
+
+// Returns a DefaultDict that maps from each eventDocID to a Set of user ids going
+export const getUsersGoingForAllEvents = async () => {
+  var attendees = {};
+  var usersRef = firestore.collection('users');
+  await usersRef
+    .get()
+    .then(snapshot => {
+      snapshot.forEach(userDoc => {
+        try {
+          let going = userDoc.get('event_refs.going');
+          going.forEach(eventRef => {
+            if (!(eventRef.id in attendees)) {
+              attendees[eventRef.id] = [];
+            }
+            attendees[eventRef.id].push(userDoc.id);
+          });
+        } catch (error) {
+          console.log(error);
+        }
+      });
+    })
+    .catch(error => {
+      console.log(error);
+      return null;
+    });
+  return attendees;
+};

--- a/volunta/firebase/api.js
+++ b/volunta/firebase/api.js
@@ -73,7 +73,7 @@ export const getEventsForCommunity = async () => {
 
 // Logic to retrieve organization name from an organization reference
 export const getOrganizationName = async orgRef => {
-  name = '';
+  let name = '';
   await orgRef
     .get()
     .then(snapshot => {
@@ -84,6 +84,21 @@ export const getOrganizationName = async orgRef => {
       return null;
     });
   return name;
+};
+
+// Retrieve logo url given an organization reference
+export const getOrganizationLogo = async orgRef => {
+  let logo = '';
+  await orgRef
+    .get()
+    .then(snapshot => {
+      logo = snapshot.get('logo_url');
+    })
+    .catch(error => {
+      console.log(error);
+      return null;
+    });
+  return logo;
 };
 
 // Given a user doc id, returns a set with the doc ids of all events the user is interested in

--- a/volunta/package-lock.json
+++ b/volunta/package-lock.json
@@ -4297,7 +4297,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4318,12 +4319,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4338,17 +4341,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4465,7 +4471,8 @@
         "inherits": {
           "version": "2.0.3",
           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4477,6 +4484,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4491,6 +4499,7 @@
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -4498,12 +4507,14 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4522,6 +4533,7 @@
           "version": "0.5.1",
           "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -4602,7 +4614,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -4614,6 +4627,7 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -4699,7 +4713,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -4735,6 +4750,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -4754,6 +4770,7 @@
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -4797,12 +4814,14 @@
         "wrappy": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
-          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "optional": true
         }
       }
     },

--- a/volunta/screens/CommunityScreen.js
+++ b/volunta/screens/CommunityScreen.js
@@ -62,13 +62,14 @@ export default class CommunityScreen extends React.Component {
     const interestedEventDocIds = await getAllUserInterestedEventsDocIds(
       c.TEST_USER_ID
     );
-    
 
     //TODO change this to be the actual community members
-    const communityMembers= await firestore.collection('users')
+    const communityMembers = await firestore
+      .collection('users')
       .get()
-      .then(async snapshot => 
-        await getUsersAttributes(snapshot.docs, ['name', 'profile_pic_url'])
+      .then(
+        async snapshot =>
+          await getUsersAttributes(snapshot.docs, ['name', 'profile_pic_url'])
       );
     this.setState({
       upcomingEvents,
@@ -82,9 +83,11 @@ export default class CommunityScreen extends React.Component {
   };
 
   // onPress function to pass to CommunityProfileEventCards using screen navigation
-  _onPressOpenEventPage = event => {
+  _onPressOpenEventPage = (event, org_name, interested) => {
     this.props.navigation.push('Event', {
       event,
+      org_name,
+      interested,
     });
   };
 
@@ -117,14 +120,16 @@ export default class CommunityScreen extends React.Component {
             <Text style={styles.titleText}>{'in my community'}</Text>
           </View>
           <View style={styles.facepileContainer}>
-            {this.state.communityMembers !== [] && (<Facepile
-              totalWidth={335}
-              maxNumImages={10}
-              imageDiameter={50}
-              members={this.state.communityMembers}
-              pileTitle='Community Members'
-              navigation={this.props.navigation}
-            />)}
+            {this.state.communityMembers !== [] && (
+              <Facepile
+                totalWidth={335}
+                maxNumImages={10}
+                imageDiameter={50}
+                members={this.state.communityMembers}
+                pileTitle="Community Members"
+                navigation={this.props.navigation}
+              />
+            )}
           </View>
 
           <View style={styles.middleText}>

--- a/volunta/screens/EventScreen.js
+++ b/volunta/screens/EventScreen.js
@@ -101,7 +101,7 @@ export default class EventScreen extends React.Component {
   // Event from_date and to_date --> EventPageAboutSection
   // userIDs of users attending / interested --> Facepile + number in user's community
   render() {
-    const {
+    var {
       event,
       interested,
       facePileAttendees,
@@ -112,6 +112,33 @@ export default class EventScreen extends React.Component {
       numGoing,
       numGoingFromCommunity,
     } = this.state;
+
+    // Render Facepile view only if there are users interested or going
+    var facepileView = (
+      <Text style={[styles.detailText, styles.numGoingText]}>
+        Be the first to join the event!
+      </Text>
+    );
+    if (numGoing > 0) {
+      facepileView = (
+        <View>
+          <Facepile
+            totalWidth={335}
+            maxNumImages={10}
+            imageDiameter={50}
+            members={facePileAttendees}
+            pileTitle="Event Attendees"
+            navigation={this.props.navigation}
+          />
+          <Text style={[styles.detailText, styles.numGoingText]}>
+            {numGoing +
+              ' going or interested including ' +
+              numGoingFromCommunity +
+              ' from your community'}
+          </Text>
+        </View>
+      );
+    }
 
     if (!refreshing) {
       return (
@@ -131,22 +158,7 @@ export default class EventScreen extends React.Component {
           <View style={styles.divider}>
             <View style={styles.facepileContainer}>
               <Text style={styles.sectionText}>{"Who's going?"}</Text>
-              {facePileAttendees !== [] && (
-                <Facepile
-                  totalWidth={335}
-                  maxNumImages={10}
-                  imageDiameter={50}
-                  members={facePileAttendees}
-                  pileTitle="Event Attendees"
-                  navigation={this.props.navigation}
-                />
-              )}
-              <Text style={[styles.detailText, styles.numGoingText]}>
-                {numGoing +
-                  ' going or interested including ' +
-                  numGoingFromCommunity +
-                  ' from your community'}
-              </Text>
+              {facepileView}
             </View>
           </View>
           <View style={styles.facepileContainer}>

--- a/volunta/screens/EventScreen.js
+++ b/volunta/screens/EventScreen.js
@@ -5,6 +5,7 @@ import {
   StyleSheet,
   ScrollView,
   ActivityIndicator,
+  Dimensions,
 } from 'react-native';
 import EventPageHeader from '../components/EventPageHeader';
 import EventPageButtonBar from '../components/EventPageButtonBar';
@@ -36,17 +37,17 @@ export default class EventScreen extends React.Component {
   _loadData = async () => {
     const org_ref = this.state.event.org_ref;
 
-    const org_name = await getOrganizationName(org_ref);
-    const org_logo = await getOrganizationLogo(org_ref);
-
-    //TODO change this to be the actual attendees
-    const attendees = await firestore
-      .collection('users')
-      .get()
-      .then(
-        async snapshot =>
-          await getUsersAttributes(snapshot.docs, ['name', 'profile_pic_url'])
-      );
+    const [org_name, org_logo, attendees] = await Promise.all([
+      getOrganizationName(org_ref),
+      getOrganizationLogo(org_ref),
+      firestore
+        .collection('users')
+        .get()
+        .then(
+          async snapshot =>
+            await getUsersAttributes(snapshot.docs, ['name', 'profile_pic_url'])
+        ),
+    ]);
 
     this.setState({
       attendees: attendees,
@@ -108,7 +109,11 @@ export default class EventScreen extends React.Component {
         </ScrollView>
       );
     } else {
-      return <ActivityIndicator />;
+      return (
+        <View style={styles.activityIndicator}>
+          <ActivityIndicator size={0} />
+        </View>
+      );
     }
   }
 }
@@ -134,5 +139,8 @@ const styles = StyleSheet.create({
   numGoingText: {
     marginTop: 10,
     marginBottom: 3,
+  },
+  activityIndicator: {
+    marginTop: 300,
   },
 });

--- a/volunta/screens/EventScreen.js
+++ b/volunta/screens/EventScreen.js
@@ -23,9 +23,10 @@ export default class EventScreen extends React.Component {
     super(props);
     this.state = {
       event: this.props.navigation.getParam('event'),
+      interested: this.props.navigation.getParam('interested'),
       attendees: [],
       refreshing: true,
-      org_name: '',
+      org_name: this.props.navigation.getParam('org_name'),
       org_logo: '../assets/images/logo.png', //This never actually renders, but avoids empty string warnings.
     };
   }
@@ -37,8 +38,7 @@ export default class EventScreen extends React.Component {
   _loadData = async () => {
     const org_ref = this.state.event.org_ref;
 
-    const [org_name, org_logo, attendees] = await Promise.all([
-      getOrganizationName(org_ref),
+    const [org_logo, attendees] = await Promise.all([
       getOrganizationLogo(org_ref),
       firestore
         .collection('users')
@@ -52,9 +52,7 @@ export default class EventScreen extends React.Component {
     this.setState({
       attendees: attendees,
       refreshing: false,
-      org_name: org_name,
       org_logo: org_logo,
-      loading: false,
     });
   };
 
@@ -64,7 +62,14 @@ export default class EventScreen extends React.Component {
   // Event from_date and to_date --> EventPageAboutSection
   // userIDs of users attending / interested --> Facepile + number in user's community
   render() {
-    const { event, attendees, refreshing, org_name, org_logo } = this.state;
+    const {
+      event,
+      interested,
+      attendees,
+      refreshing,
+      org_name,
+      org_logo,
+    } = this.state;
     if (!refreshing) {
       return (
         <ScrollView>
@@ -74,7 +79,7 @@ export default class EventScreen extends React.Component {
             organizationLogo={org_logo}
             coverPhoto={event.cover_url}
           />
-          <EventPageButtonBar interested={false} going={true} />
+          <EventPageButtonBar interested={interested} going={true} />
           <EventPageAboutSection
             fromDate={event.from_date}
             toDate={event.to_date}

--- a/volunta/screens/EventScreen.js
+++ b/volunta/screens/EventScreen.js
@@ -5,7 +5,7 @@ import EventPageButtonBar from '../components/EventPageButtonBar';
 import EventPageAboutSection from '../components/EventPageAboutSection';
 import Facepile from '../components/Facepile';
 import { firestore } from '../firebase/firebase';
-import { getUsersAttributes } from '../firebase/api';
+import { getUsersAttributes, getOrganizationName } from '../firebase/api';
 
 export default class EventScreen extends React.Component {
   constructor(props) {
@@ -14,6 +14,7 @@ export default class EventScreen extends React.Component {
       event: this.props.navigation.getParam('event'),
       attendees: [],
       refreshing: false,
+      org_name: '',
     };
   }
 
@@ -25,6 +26,8 @@ export default class EventScreen extends React.Component {
     this.setState({
       refreshing: true,
     });
+
+    const org_name = await getOrganizationName(this.props.event.org_ref);
 
     //TODO change this to be the actual attendees
     const attendees = await firestore
@@ -38,6 +41,7 @@ export default class EventScreen extends React.Component {
     this.setState({
       refreshing: false,
       attendees,
+      org_name,
     });
   };
 
@@ -47,14 +51,15 @@ export default class EventScreen extends React.Component {
   // Event from_date and to_date --> EventPageAboutSection
   // userIDs of users attending / interested --> Facepile + number in user's community
   render() {
-    const event = this.state.event;
+    const { event, attendees, refreshing, org_name } = this.state;
+    // const event = this.state.event;
     return (
       <ScrollView>
         <EventPageHeader
           eventTitle={event.title}
-          organizationName={'Girls Teaching Girls to Code'}
+          organizationName={org_name}
           organizationLogo={'https://i.imgur.com/1GvJojw.png'}
-          coverPhoto={'https://i.imgur.com/PZB82WT.jpg'}
+          coverPhoto={event.cover_url}
         />
         <EventPageButtonBar interested={false} going={true} />
         <EventPageAboutSection

--- a/volunta/screens/EventScreen.js
+++ b/volunta/screens/EventScreen.js
@@ -1,11 +1,21 @@
 import React from 'react';
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  ActivityIndicator,
+} from 'react-native';
 import EventPageHeader from '../components/EventPageHeader';
 import EventPageButtonBar from '../components/EventPageButtonBar';
 import EventPageAboutSection from '../components/EventPageAboutSection';
 import Facepile from '../components/Facepile';
 import { firestore } from '../firebase/firebase';
-import { getUsersAttributes, getOrganizationName } from '../firebase/api';
+import {
+  getUsersAttributes,
+  getOrganizationName,
+  getOrganizationLogo,
+} from '../firebase/api';
 
 export default class EventScreen extends React.Component {
   constructor(props) {
@@ -13,8 +23,9 @@ export default class EventScreen extends React.Component {
     this.state = {
       event: this.props.navigation.getParam('event'),
       attendees: [],
-      refreshing: false,
+      refreshing: true,
       org_name: '',
+      org_logo: '../assets/images/logo.png', //This never actually renders, but avoids empty string warnings.
     };
   }
 
@@ -23,11 +34,10 @@ export default class EventScreen extends React.Component {
   }
 
   _loadData = async () => {
-    this.setState({
-      refreshing: true,
-    });
+    const org_ref = this.state.event.org_ref;
 
-    const org_name = await getOrganizationName(this.props.event.org_ref);
+    const org_name = await getOrganizationName(org_ref);
+    const org_logo = await getOrganizationLogo(org_ref);
 
     //TODO change this to be the actual attendees
     const attendees = await firestore
@@ -39,9 +49,11 @@ export default class EventScreen extends React.Component {
       );
 
     this.setState({
+      attendees: attendees,
       refreshing: false,
-      attendees,
-      org_name,
+      org_name: org_name,
+      org_logo: org_logo,
+      loading: false,
     });
   };
 
@@ -51,50 +63,53 @@ export default class EventScreen extends React.Component {
   // Event from_date and to_date --> EventPageAboutSection
   // userIDs of users attending / interested --> Facepile + number in user's community
   render() {
-    const { event, attendees, refreshing, org_name } = this.state;
-    // const event = this.state.event;
-    return (
-      <ScrollView>
-        <EventPageHeader
-          eventTitle={event.title}
-          organizationName={org_name}
-          organizationLogo={'https://i.imgur.com/1GvJojw.png'}
-          coverPhoto={event.cover_url}
-        />
-        <EventPageButtonBar interested={false} going={true} />
-        <EventPageAboutSection
-          fromDate={event.from_date}
-          toDate={event.to_date}
-          location={event.location}
-        />
-        <View style={styles.divider}>
+    const { event, attendees, refreshing, org_name, org_logo } = this.state;
+    if (!refreshing) {
+      return (
+        <ScrollView>
+          <EventPageHeader
+            eventTitle={event.title}
+            organizationName={org_name}
+            organizationLogo={org_logo}
+            coverPhoto={event.cover_url}
+          />
+          <EventPageButtonBar interested={false} going={true} />
+          <EventPageAboutSection
+            fromDate={event.from_date}
+            toDate={event.to_date}
+            location={event.location}
+          />
+          <View style={styles.divider}>
+            <View style={styles.facepileContainer}>
+              <Text style={styles.sectionText}>{"Who's going?"}</Text>
+              {attendees !== [] && (
+                <Facepile
+                  totalWidth={335}
+                  maxNumImages={10}
+                  imageDiameter={50}
+                  members={attendees}
+                  pileTitle="Event Attendees"
+                  navigation={this.props.navigation}
+                />
+              )}
+              <Text style={[styles.detailText, styles.numGoingText]}>
+                {'84 going or interested including 36 from your community'}
+              </Text>
+            </View>
+          </View>
           <View style={styles.facepileContainer}>
-            <Text style={styles.sectionText}>{"Who's going?"}</Text>
-            {this.state.attendees !== [] && (
-              <Facepile
-                totalWidth={335}
-                maxNumImages={10}
-                imageDiameter={50}
-                members={this.state.attendees}
-                pileTitle="Event Attendees"
-                navigation={this.props.navigation}
-              />
-            )}
-            <Text style={[styles.detailText, styles.numGoingText]}>
-              {'84 going or interested including 36 from your community'}
+            <Text style={styles.sectionText}>{'Details'}</Text>
+            <Text style={styles.detailText}>
+              {
+                "American Lung Association's annual Fight For Air Climb is coming up on June 1st at 555 California Street in San Francisco!! We need help with registration, food, kids crafts, cheering on our climbers, event set-up and take down, and more. Please reach out to us if you are interested!\n\nThe Fight For Air Climb, a competitive stair climb to the top of a skyscraper, is an opportunity for the American Lung Association and the Bay Area community to rally together and raise funds to support lung disease research, anti-tobacco policies, and clean air initiatives. \n\nCOME JOIN US! Register as a Volunteer at http://FightForAirClimb.org/SanFrancisco"
+              }
             </Text>
           </View>
-        </View>
-        <View style={styles.facepileContainer}>
-          <Text style={styles.sectionText}>{'Details'}</Text>
-          <Text style={styles.detailText}>
-            {
-              "American Lung Association's annual Fight For Air Climb is coming up on June 1st at 555 California Street in San Francisco!! We need help with registration, food, kids crafts, cheering on our climbers, event set-up and take down, and more. Please reach out to us if you are interested!\n\nThe Fight For Air Climb, a competitive stair climb to the top of a skyscraper, is an opportunity for the American Lung Association and the Bay Area community to rally together and raise funds to support lung disease research, anti-tobacco policies, and clean air initiatives. \n\nCOME JOIN US! Register as a Volunteer at http://FightForAirClimb.org/SanFrancisco"
-            }
-          </Text>
-        </View>
-      </ScrollView>
-    );
+        </ScrollView>
+      );
+    } else {
+      return <ActivityIndicator />;
+    }
   }
 }
 

--- a/volunta/screens/FeedScreen.js
+++ b/volunta/screens/FeedScreen.js
@@ -92,9 +92,11 @@ export default class FeedScreen extends React.Component {
   };
 
   // Function we pass to EventCard, pushes screen onto current stack with the corresponding event page
-  _onPressEventCard = event => {
+  _onPressEventCard = (event, org_name, interested) => {
     this.props.navigation.push('Event', {
       event,
+      org_name,
+      interested,
     });
   };
 

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -72,9 +72,11 @@ export default class ProfileScreen extends React.Component {
   };
 
   // onPress function to pass to CommunityProfileEventCards using screen navigation
-  _onPressOpenEventPage = event => {
+  _onPressOpenEventPage = (event, org_name, interested) => {
     this.props.navigation.push('Event', {
       event,
+      org_name,
+      interested,
     });
   };
 

--- a/volunta/utils.js
+++ b/volunta/utils.js
@@ -3,8 +3,8 @@
 // Pass in from_date or to_date from an event object
 // Returns date in 'MM/DD/YY' string format
 export const timestampToDate = timestamp => {
-  let date = new Date(null);
-  date.setSeconds(timestamp.seconds);
+  let date = new Date(0);
+  date.setUTCSeconds(timestamp.seconds);
   let month = date.getMonth() + 1;
   let day = date.getDate();
   let year = date.getFullYear();
@@ -51,4 +51,31 @@ export const dateToWords = date => {
   // Add year prefix
   let year = '20' + result[3];
   return month + ' ' + day + ', ' + year;
+};
+
+// Pass in to_date or from_date from an event object
+// Returns time of day in '12:00PM' format
+export const timestampToTimeOfDay = timestamp => {
+  let date = new Date(0);
+  date.setUTCSeconds(timestamp.seconds);
+  let hours = date.getHours();
+  let minutes = date.getMinutes();
+  let meridian = 'AM';
+  if (hours >= 12) {
+    meridian = 'PM';
+  }
+  if (hours == 0) {
+    hours = 12;
+  } else if (hours > 12) {
+    hours = hours - 12;
+  }
+  hours = hours.toString();
+
+  if (minutes < 10) {
+    minutes = minutes.toString();
+    minutes = '0' + minutes;
+  } else {
+    minutes = minutes.toString();
+  }
+  return hours + ':' + minutes + ' ' + meridian;
 };

--- a/volunta/utils.js
+++ b/volunta/utils.js
@@ -25,3 +25,30 @@ export class DefaultDict {
     );
   }
 }
+
+export const monthNames = [
+  'January',
+  'February',
+  'March',
+  'April',
+  'May',
+  'June',
+  'July',
+  'August',
+  'September',
+  'October',
+  'November',
+  'December',
+];
+
+// Pass in date in 'MM/DD/YY' string format
+// Returns date formatted like: 'June 20, 2019'
+export const dateToWords = date => {
+  let dateRegex = /(\d+)\/(\d+)\/(\d+)/;
+  let result = dateRegex.exec(date);
+  let month = monthNames[Number(result[1])];
+  let day = result[2];
+  // Add year prefix
+  let year = '20' + result[3];
+  return month + ' ' + day + ', ' + year;
+};

--- a/volunta/utils.js
+++ b/volunta/utils.js
@@ -15,7 +15,6 @@ export const timestampToDate = timestamp => {
 
 // Similar to default dict in python
 // Use: const counts = new DefaultDict(0)
-//      console.log(counts.c); // 0
 export class DefaultDict {
   constructor(defaultVal) {
     return new Proxy(


### PR DESCRIPTION
Everything displaying on the event screen is now pulling from our database. Some fields are passed directly from the event cards (organization name, whether user is interested), others come from the event object itself, and others now have logic built out. 

I also played around with a loading screen so that if the data in loadData hasn't been retrieved yet, loading displays. Might be good practice for other screens in the future as well. Looks a little cleaner so we can get the logo, cover photo, etc. before showing everything with different images / content coming in at different times. (See videos below). The difference is that without the loading screen, the sizes of the items (like space for the facepile bar) only expands after you're in the screen / images fetched after. You can see the Facepile items still loading after the loading screen, but that's because of the component itself or image sizes that we could optimize later. 

With loading screen: https://vimeo.com/335516939
Without: https://vimeo.com/335516997

Next steps: pull-down refresh functionality, add interest bubbles component, make going / interest buttons clickable and send data to database