### PR TITLE
Fix duplicate attendees bug and add refresh functionality to EventScreen

### DIFF
--- a/volunta/firebase/api.js
+++ b/volunta/firebase/api.js
@@ -342,3 +342,15 @@ export const getEventInterestNames = async eventRef => {
     })
   );
 };
+
+// Takes in a reference to an event object
+// Returns the actual event object with data we need
+export const getEvent = async eventRef => {
+  var event = {};
+  event = await eventRef.get().then(snapshot => {
+    var data = snapshot.data();
+    data.doc_id = snapshot.id;
+    return data;
+  });
+  return event;
+};

--- a/volunta/screens/EventScreen.js
+++ b/volunta/screens/EventScreen.js
@@ -19,6 +19,7 @@ import {
   getCommunityMemberUserIds,
   getUserCommunity,
   getEventInterestNames,
+  getEvent,
 } from '../firebase/api';
 import * as c from '../firebase/fb_constants';
 
@@ -44,8 +45,10 @@ export default class EventScreen extends React.Component {
   }
 
   _loadData = async () => {
-    const event = this.state.event;
+    var event = this.state.event;
     const eventRef = firestore.collection('events').doc(event.doc_id);
+    // Get event to load any updates on refresh
+    event = await getEvent(eventRef);
 
     const [
       // Get list of interests that correspond to the event
@@ -120,6 +123,7 @@ export default class EventScreen extends React.Component {
     ).length;
 
     this.setState({
+      event,
       facePileAttendees,
       refreshing: false,
       orgLogo,


### PR DESCRIPTION
- Fixed bug in EventScreen where users who were both interested in and going to one event were displayed twice. We ultimately want to count users who are going first (to eventually display in a going list when the Facepile is clicked) and then those who aren't going should be displayed as interested. 
Fixes #72 

- Added pull-down refresh functionality for EventScreen. 

[A note: some details in the EventScreen, when refreshed, won't change if the card that was clicked to navigate to the screen hasn't updated. This is because the actual event object (which includes location, title, organization, etc.) was pulled from the event card to save time. We can consider having this initial event object be set in the constructor and then fetching an updated version with the ID when we're loading other data.]

EDIT: added the fix I talked about above 
Next: pass event back to parent event card in case of changes