### PR TITLE
Add loading screen to CommunityScreen

### DIFF
--- a/volunta/screens/CommunityScreen.js
+++ b/volunta/screens/CommunityScreen.js
@@ -5,6 +5,7 @@ import {
   Text,
   ScrollView,
   RefreshControl,
+  ActivityIndicator,
 } from 'react-native';
 import Facepile from '../components/Facepile';
 import CommunityCoverPhoto from '../components/CommunityCoverPhoto';
@@ -98,60 +99,68 @@ export default class CommunityScreen extends React.Component {
       refreshing,
     } = this.state;
 
-    return (
-      // Invisible ScrollView component to add pull-down refresh functionality
-      <ScrollView
-        refreshControl={
-          <RefreshControl
-            refreshing={refreshing}
-            onRefresh={() => this._loadData()}
-          />
-        }
-      >
-        <View>
-          <CommunityCoverPhoto
-            communityPhoto={communityPhoto}
-            communityName={communityName}
-          />
-          <View style={styles.topText}>
-            <Text style={styles.titleText}>{'in my community'}</Text>
-          </View>
-          <View style={styles.facepileContainer}>
-            {this.state.communityMembers !== [] && (
-              <Facepile
-                totalWidth={335}
-                maxNumImages={10}
-                imageDiameter={50}
-                members={this.state.communityMembers}
-                pileTitle="Community Members"
-                navigation={this.props.navigation}
-              />
-            )}
-          </View>
-
-          <View style={styles.middleText}>
-            <Text style={styles.titleText}>{'coming up'}</Text>
-          </View>
-          <View style={styles.upcomingScroll}>
-            <CommunityProfileEventCardHorizontalScroll
-              events={upcomingEvents}
-              onPress={this._onPressOpenEventPage}
-              interestedIDs={interestedEventDocIds}
+    if (!refreshing) {
+      return (
+        // Invisible ScrollView component to add pull-down refresh functionality
+        <ScrollView
+          refreshControl={
+            <RefreshControl
+              refreshing={refreshing}
+              onRefresh={() => this._loadData()}
             />
-          </View>
-          <View style={styles.bottomText}>
-            <Text style={styles.titleText}>{"how we've helped"}</Text>
-            <View style={styles.pastScroll}>
+          }
+        >
+          <View>
+            <CommunityCoverPhoto
+              communityPhoto={communityPhoto}
+              communityName={communityName}
+            />
+            <View style={styles.topText}>
+              <Text style={styles.titleText}>{'in my community'}</Text>
+            </View>
+            <View style={styles.facepileContainer}>
+              {this.state.communityMembers !== [] && (
+                <Facepile
+                  totalWidth={335}
+                  maxNumImages={10}
+                  imageDiameter={50}
+                  members={this.state.communityMembers}
+                  pileTitle="Community Members"
+                  navigation={this.props.navigation}
+                />
+              )}
+            </View>
+
+            <View style={styles.middleText}>
+              <Text style={styles.titleText}>{'coming up'}</Text>
+            </View>
+            <View style={styles.upcomingScroll}>
               <CommunityProfileEventCardHorizontalScroll
-                events={pastEvents}
-                interestedIDs={interestedEventDocIds}
+                events={upcomingEvents}
                 onPress={this._onPressOpenEventPage}
+                interestedIDs={interestedEventDocIds}
               />
             </View>
+            <View style={styles.bottomText}>
+              <Text style={styles.titleText}>{"how we've helped"}</Text>
+              <View style={styles.pastScroll}>
+                <CommunityProfileEventCardHorizontalScroll
+                  events={pastEvents}
+                  interestedIDs={interestedEventDocIds}
+                  onPress={this._onPressOpenEventPage}
+                />
+              </View>
+            </View>
           </View>
+        </ScrollView>
+      );
+    } else {
+      return (
+        <View style={styles.activityIndicator}>
+          <ActivityIndicator size={0} />
         </View>
-      </ScrollView>
-    );
+      );
+    }
   }
 }
 
@@ -190,5 +199,8 @@ const styles = StyleSheet.create({
     left: 15,
     top: 7,
     height: 0, //removes extra blank space at bottom of scroll
+  },
+  activityIndicator: {
+    marginTop: 300,
   },
 });

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -83,17 +83,19 @@ export default class ProfileScreen extends React.Component {
   };
 
   _onPressSettings = () => {
-    ActionSheetIOS.showActionSheetWithOptions({
-      options: ['Cancel', 'Logout', 'Edit Profile'],
-      destructiveButtonIndex: 1,
-      cancelButtonIndex: 0,
-    },
-    (buttonIndex) => {
-      if (buttonIndex === 1) {
-        firebase.auth().signOut();
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        options: ['Cancel', 'Logout', 'Edit Profile'],
+        destructiveButtonIndex: 1,
+        cancelButtonIndex: 0,
+      },
+      buttonIndex => {
+        if (buttonIndex === 1) {
+          firebase.auth().signOut();
+        }
       }
-    },);
-  }
+    );
+  };
 
   render() {
     const {
@@ -123,7 +125,10 @@ export default class ProfileScreen extends React.Component {
               <Text style={styles.personName}>Kanye West</Text>
               <Text style={styles.communityName}>Stanford University</Text>
             </View>
-            <TouchableOpacity onPress={this._onPressSettings} style={styles.editIcon}>
+            <TouchableOpacity
+              onPress={this._onPressSettings}
+              style={styles.editIcon}
+            >
               <Ionicons name="ios-settings" size={30} color="#0081AF" />
             </TouchableOpacity>
           </View>


### PR DESCRIPTION
Added a loading screen, the way it's currently done for EventScreen, to CommunityScreen. Looks cleaner so the sizing of components isn't shown to the viewer, and everything just fills in in place. Should probably do the same for profile once Cody's PRs go through. The only changes were adding an if statement to the beginning of render and an else to display the loading page; the rest is just indenting.

Before: https://vimeo.com/336911605
After: https://vimeo.com/336911614