### PR TITLE
Add going icon next to interested icon on CommunityProfileEventCard

### DIFF
--- a/volunta/components/CommunityProfileEventCard.js
+++ b/volunta/components/CommunityProfileEventCard.js
@@ -23,7 +23,6 @@ export default class CommunityProfileEventCard extends React.Component {
 
   render() {
     const { event, interested, going, onPress } = this.props;
-    console.log(event.title + ': ' + going);
     const { date, org_name } = this.state;
     const upcoming = event.status == 'upcoming';
     return (
@@ -129,7 +128,6 @@ const styles = StyleSheet.create({
   },
   bookmarkIcon: {
     paddingRight: 3,
-    justifyContent: 'flex-end',
   },
   detailTextContainer: {
     marginLeft: 10,

--- a/volunta/components/CommunityProfileEventCard.js
+++ b/volunta/components/CommunityProfileEventCard.js
@@ -22,7 +22,8 @@ export default class CommunityProfileEventCard extends React.Component {
   }
 
   render() {
-    const { event, interested, onPress } = this.props;
+    const { event, interested, going, onPress } = this.props;
+    console.log(event.title + ': ' + going);
     const { date, org_name } = this.state;
     const upcoming = event.status == 'upcoming';
     return (
@@ -54,6 +55,11 @@ export default class CommunityProfileEventCard extends React.Component {
                 }
               >
                 <Text style={styles.dateText}>{date}</Text>
+                <Icon
+                  name={'check-circle-outline'}
+                  size={23}
+                  color={going ? '#0081AF' : 'grey'}
+                />
                 <Icon
                   name={'star-circle-outline'}
                   size={23}
@@ -109,6 +115,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     fontWeight: 'normal',
     color: '#838383',
+    flex: 1,
   },
   textContainer: {
     flex: 1,
@@ -121,7 +128,8 @@ const styles = StyleSheet.create({
     paddingRight: 5,
   },
   bookmarkIcon: {
-    paddingLeft: 95,
+    paddingRight: 3,
+    justifyContent: 'flex-end',
   },
   detailTextContainer: {
     marginLeft: 10,

--- a/volunta/components/CommunityProfileEventCard.js
+++ b/volunta/components/CommunityProfileEventCard.js
@@ -2,6 +2,7 @@ import React from 'react';
 import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
 import { timestampToDate } from '../utils';
 import { getOrganizationName } from '../firebase/api';
+import Colors from '../constants/Colors';
 
 import { Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 
@@ -57,13 +58,13 @@ export default class CommunityProfileEventCard extends React.Component {
                 <Icon
                   name={'check-circle-outline'}
                   size={23}
-                  color={going ? '#0081AF' : 'grey'}
+                  color={going ? Colors.iconBlue : 'grey'}
                 />
                 <Icon
                   name={'star-circle-outline'}
                   size={23}
                   style={styles.bookmarkIcon}
-                  color={interested ? '#0081AF' : 'grey'}
+                  color={interested ? Colors.iconBlue : 'grey'}
                 />
               </View>
             </View>

--- a/volunta/components/CommunityProfileEventCardHorizontalScroll.js
+++ b/volunta/components/CommunityProfileEventCardHorizontalScroll.js
@@ -12,6 +12,7 @@ export default class CommunityProfileEventCardHorizontalScroll extends React.Com
       <CommunityProfileEventCard
         event={item}
         interested={this.props.interestedIDs.has(item.doc_id)}
+        going={this.props.goingIDs.has(item.doc_id)}
         onPress={this.props.onPress}
       />
     );

--- a/volunta/firebase/api.js
+++ b/volunta/firebase/api.js
@@ -256,7 +256,7 @@ export const getOrganizationLogo = async orgRef => {
 // Given a user doc id, returns a set with the doc ids of all events the user is interested in
 // Returns none in case of error.
 export const getAllUserInterestedEventsDocIds = async userDocId => {
-  interested = new Set();
+  let interested = new Set();
   await firestore
     .collection('users')
     .doc(userDocId)
@@ -270,6 +270,25 @@ export const getAllUserInterestedEventsDocIds = async userDocId => {
       return null;
     });
   return interested;
+};
+
+// Given a user doc id, returns a set with the doc ids of all events the user is going to
+// Returns none in case of error.
+export const getAllUserGoingEventsDocIds = async userDocId => {
+  let going = new Set();
+  await firestore
+    .collection('users')
+    .doc(userDocId)
+    .get()
+    .then(snapshot => {
+      let going_refs = snapshot.get('event_refs.going');
+      going_refs.forEach(ref => going.add(ref.id));
+    })
+    .catch(error => {
+      console.log(error);
+      return null;
+    });
+  return going;
 };
 
 // Retrieve the community reference object for the current user

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -14,7 +14,6 @@ import ExpandableInterests from '../components/ExpandableInterests';
 import CommunityProfileEventCardHorizontalScroll from '../components/CommunityProfileEventCardHorizontalScroll';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import {
-  getEventsForCommunity,
   getAllUserInterestedEventsDocIds,
   getUsersAttributes,
   getUserInterestNames,
@@ -22,6 +21,7 @@ import {
   getProfilePhoto,
   getProfileName,
   getProfileCommunityName,
+  getAllUserGoingEventsDocIds,
 } from '../firebase/api';
 import { firestore } from '../firebase/firebase';
 import * as c from '../firebase/fb_constants';
@@ -37,6 +37,7 @@ export default class ProfileScreen extends React.Component {
       pastEvents: [],
       volunteerNetwork: [],
       interestedEventDocIds: new Set(),
+      goingEventDocIds: new Set(),
       refreshing: true,
       interests: [],
     };
@@ -48,17 +49,15 @@ export default class ProfileScreen extends React.Component {
 
   //TODO: change this to be profile-specific and consolidate profile/community logic in a shared space
   _loadData = async () => {
-    //If we are navigating to another user's profile
+    // If we are navigating to another user's profile
+    // TODO: Change default to current user
     const userId = this.props.navigation.getParam('userId', c.TEST_USER_ID);
     const [
       [upcomingEvents, pastEvents, ongoingEvents],
-      interestedEventDocIds,
       volunteerNetwork,
       interests,
     ] = await Promise.all([
       getEventsForProfile(userId),
-      // Get doc IDs the current user has bookmarked
-      getAllUserInterestedEventsDocIds(userId),
       //TODO change this to actual volunteer network
       firestore
         .collection('users')
@@ -73,6 +72,12 @@ export default class ProfileScreen extends React.Component {
     // get name of user
     const profileName = await getProfileName(userId);
 
+    // Get doc IDs the current user has bookmarked and is going to
+    const interestedEventDocIds = await getAllUserInterestedEventsDocIds(
+      userId
+    );
+    const goingEventDocIds = await getAllUserGoingEventsDocIds(userId);
+
     // get url for profile picture
     const profilePhoto = await getProfilePhoto(userId);
 
@@ -85,10 +90,10 @@ export default class ProfileScreen extends React.Component {
       profileName,
       profilePhoto,
       communityName,
-      interestedEventDocIds,
-      refreshing: false,
       volunteerNetwork,
-      userId,
+      interestedEventDocIds,
+      goingEventDocIds,
+      refreshing: false,
       interests,
     });
   };
@@ -122,6 +127,7 @@ export default class ProfileScreen extends React.Component {
       upcomingEvents,
       pastEvents,
       interestedEventDocIds,
+      goingEventDocIds,
       refreshing,
       interests,
     } = this.state;
@@ -173,6 +179,7 @@ export default class ProfileScreen extends React.Component {
                 events={upcomingEvents}
                 interestedIDs={interestedEventDocIds}
                 onPress={this._onPressOpenEventPage}
+                goingIDs={goingEventDocIds}
               />
             </View>
           </View>
@@ -182,6 +189,7 @@ export default class ProfileScreen extends React.Component {
               events={pastEvents}
               interestedIDs={interestedEventDocIds}
               onPress={this._onPressOpenEventPage}
+              goingIDs={goingEventDocIds}
             />
           </View>
           <View>


### PR DESCRIPTION
Added a going icon that displays blue if the user is going, grey otherwise. Previously, a user wouldn't know looking on the community or profile screens which events the user was RSVP'd as going to and could only see interested information. Also cleaned up async calls in CommunityScreen and will do the same for ProfileScreen after new PRs have gone through.

Fixes #65 

<img width="373" alt="Screen Shot 2019-05-17 at 3 29 03 PM" src="https://user-images.githubusercontent.com/32403070/57959886-c8d28200-78ba-11e9-8e31-6d1ff754e193.png">
