### PR TITLE
Expandable interests component

### DIFF
--- a/volunta/components/ExpandableInterests.js
+++ b/volunta/components/ExpandableInterests.js
@@ -3,17 +3,20 @@ import Accordion from 'react-native-collapsible/Accordion';
 import ProfilePageInterests from './ProfilePageInterests';
 
 const SIDE_MARGIN = 20;
-const SECTIONS = [
-  {
-    title: 'First',
-    content: 'Lorem ipsum...',
-  },
-];
+const SECTIONS = [{}];
 
+// TODO: comment this component
+// Used https://github.com/oblador/react-native-collapsible
+// TODO: fetch from db
+// TODO: only expand when (...) is clicked?
 export default class ExpandableInterest extends Component {
-  state = {
-    activeSections: [],
-  };
+  constructor(props) {
+    super(props);
+    this.state = {
+      activeSections: [],
+      loaded: false,
+    };
+  }
 
   _renderInterests = (numRows, split, passWidths, widths) => {
     return (
@@ -41,6 +44,7 @@ export default class ExpandableInterest extends Component {
   };
 
   // TODO: change 2 to NUM_ROWS
+  // TODO: make content clickable to collapse?
 
   passWidths = newWidths => {
     this.widths = newWidths;
@@ -55,16 +59,23 @@ export default class ExpandableInterest extends Component {
   };
 
   _renderContent = section => {
-    numRows = this.state.activeSections.length == 0 ? 0 : null;
-    split = this.state.activeSections.length == 0 ? null : -2;
-    return this._renderInterests(numRows, split, null, this.widths);
+    if (this.state.activeSections.length == 0 && !this.state.loaded) {
+      return this._renderInterests(0, null, null, this.widths);
+    } else {
+      return this._renderInterests(null, -2, null, this.widths);
+    }
   };
 
   _updateSections = activeSections => {
+    if (!this.state.loaded) {
+      this.setState({ loaded: !this.state.loaded });
+    }
     this.setState({ activeSections });
   };
 
   render() {
+    // TODO: only make it an accordion if there are extra items to show...
+    // Use 'disabled' prop
     return (
       <Accordion
         sections={SECTIONS}
@@ -72,67 +83,9 @@ export default class ExpandableInterest extends Component {
         renderHeader={this._renderHeader}
         renderContent={this._renderContent}
         onChange={this._updateSections}
+        underlayColor={'white'}
+        duration={1000}
       />
     );
   }
 }
-
-// const styles = StyleSheet.create({
-//   container: {
-//     flex: 1,
-//     backgroundColor: '#F5FCFF',
-//     paddingTop: Constants.statusBarHeight,
-//   },
-//   title: {
-//     textAlign: 'center',
-//     fontSize: 22,
-//     fontWeight: '300',
-//     marginBottom: 20,
-//   },
-//   header: {
-//     backgroundColor: '#F5FCFF',
-//     padding: 10,
-//   },
-//   headerText: {
-//     textAlign: 'center',
-//     fontSize: 16,
-//     fontWeight: '500',
-//   },
-//   content: {
-//     padding: 20,
-//     backgroundColor: '#fff',
-//   },
-//   active: {
-//     backgroundColor: 'rgba(255,255,255,1)',
-//   },
-//   inactive: {
-//     backgroundColor: 'rgba(245,252,255,1)',
-//   },
-//   selectors: {
-//     marginBottom: 10,
-//     flexDirection: 'row',
-//     justifyContent: 'center',
-//   },
-//   selector: {
-//     backgroundColor: '#F5FCFF',
-//     padding: 10,
-//   },
-//   activeSelector: {
-//     fontWeight: 'bold',
-//   },
-//   selectTitle: {
-//     fontSize: 14,
-//     fontWeight: '500',
-//     padding: 10,
-//   },
-//   multipleToggle: {
-//     flexDirection: 'row',
-//     justifyContent: 'center',
-//     marginVertical: 30,
-//     alignItems: 'center',
-//   },
-//   multipleToggle__title: {
-//     fontSize: 16,
-//     marginRight: 8,
-//   },
-// });

--- a/volunta/components/ExpandableInterests.js
+++ b/volunta/components/ExpandableInterests.js
@@ -5,16 +5,12 @@ import ProfilePageInterests from './ProfilePageInterests';
 const SIDE_MARGIN = 20;
 const SECTIONS = [{}];
 
-// TODO: comment this component
-// Used https://github.com/oblador/react-native-collapsible
-// TODO: fetch from db
-// TODO: only expand when (...) is clicked?
-// props: numRows, duration
-
 /*
 This component recieves a list of interests and displays them as an expandable/collapsable list 
 if numRows is specified and all interests can not fit in that amount of rows. We use ProfilePageInterests
 to displaye the bubbles, and Accordion to create the expandable effect
+
+// Used https://github.com/oblador/react-native-collapsible
 
 Props:
     - numRows: (optional) max number of rows of interests that we want to display.

--- a/volunta/components/ExpandableInterests.js
+++ b/volunta/components/ExpandableInterests.js
@@ -14,7 +14,8 @@ to displaye the bubbles, and Accordion to create the expandable effect
 
 Props:
     - numRows: (optional) max number of rows of interests that we want to display.
-    - duration: duration of animation in ms. 
+    - duration: duration of animation in ms.
+    - accordionRight: prop for ProfilePageInterests, put button on the right 
 */
 
 export default class ExpandableInterest extends Component {
@@ -37,6 +38,7 @@ export default class ExpandableInterest extends Component {
         sideMargin={SIDE_MARGIN}
         passWidths={passWidths}
         passedWidths={widths}
+        accordionRight={this.props.accordionRight}
         interests={[
           'public health',
           'public',
@@ -69,8 +71,6 @@ export default class ExpandableInterest extends Component {
     this.setState({ activeSections });
   };
 
-  // TODO: make content clickable to collapse?
-
   passWidths = newWidths => {
     this.widths = newWidths;
   };
@@ -102,8 +102,6 @@ export default class ExpandableInterest extends Component {
   };
 
   render() {
-    // TODO: only make it an accordion if there are extra items to show...
-    // Use 'disabled' prop
     return (
       <Accordion
         sections={SECTIONS}

--- a/volunta/components/ExpandableInterests.js
+++ b/volunta/components/ExpandableInterests.js
@@ -10,6 +10,17 @@ const SECTIONS = [{}];
 // TODO: fetch from db
 // TODO: only expand when (...) is clicked?
 // props: numRows, duration
+
+/*
+This component recieves a list of interests and displays them as an expandable/collapsable list 
+if numRows is specified and all interests can not fit in that amount of rows. We use ProfilePageInterests
+to displaye the bubbles, and Accordion to create the expandable effect
+
+Props:
+    - numRows: (optional) max number of rows of interests that we want to display.
+    - duration: duration of animation in ms. 
+*/
+
 export default class ExpandableInterest extends Component {
   constructor(props) {
     super(props);
@@ -33,12 +44,12 @@ export default class ExpandableInterest extends Component {
         interests={[
           'public health',
           'public',
-          'social good',
-          'really long interest that I love',
           'kids',
+          'social good',
           'civics',
-          'environmental',
           'beach',
+          'really long interest that I love',
+          'environmental',
           'kids',
           'health things',
           'words',

--- a/volunta/components/ExpandableInterests.js
+++ b/volunta/components/ExpandableInterests.js
@@ -1,0 +1,138 @@
+import React, { Component } from 'react';
+import Accordion from 'react-native-collapsible/Accordion';
+import ProfilePageInterests from './ProfilePageInterests';
+
+const SIDE_MARGIN = 20;
+const SECTIONS = [
+  {
+    title: 'First',
+    content: 'Lorem ipsum...',
+  },
+];
+
+export default class ExpandableInterest extends Component {
+  state = {
+    activeSections: [],
+  };
+
+  _renderInterests = (numRows, split, passWidths, widths) => {
+    return (
+      <ProfilePageInterests
+        numRows={numRows}
+        split={split}
+        sideMargin={SIDE_MARGIN}
+        passWidths={passWidths}
+        passedWidths={widths}
+        interests={[
+          'public health',
+          'public',
+          'social good',
+          'really long interest that I love',
+          'kids',
+          'civics',
+          'environmental',
+          'beach',
+          'kids',
+          'health things',
+          'words',
+        ]}
+      />
+    );
+  };
+
+  // TODO: change 2 to NUM_ROWS
+
+  passWidths = newWidths => {
+    this.widths = newWidths;
+  };
+
+  _renderHeader = section => {
+    if (this.state.activeSections.length == 0) {
+      return this._renderInterests(2, null, this.passWidths, null);
+    } else {
+      return this._renderInterests(null, 2, null, null);
+    }
+  };
+
+  _renderContent = section => {
+    numRows = this.state.activeSections.length == 0 ? 0 : null;
+    split = this.state.activeSections.length == 0 ? null : -2;
+    return this._renderInterests(numRows, split, null, this.widths);
+  };
+
+  _updateSections = activeSections => {
+    this.setState({ activeSections });
+  };
+
+  render() {
+    return (
+      <Accordion
+        sections={SECTIONS}
+        activeSections={this.state.activeSections}
+        renderHeader={this._renderHeader}
+        renderContent={this._renderContent}
+        onChange={this._updateSections}
+      />
+    );
+  }
+}
+
+// const styles = StyleSheet.create({
+//   container: {
+//     flex: 1,
+//     backgroundColor: '#F5FCFF',
+//     paddingTop: Constants.statusBarHeight,
+//   },
+//   title: {
+//     textAlign: 'center',
+//     fontSize: 22,
+//     fontWeight: '300',
+//     marginBottom: 20,
+//   },
+//   header: {
+//     backgroundColor: '#F5FCFF',
+//     padding: 10,
+//   },
+//   headerText: {
+//     textAlign: 'center',
+//     fontSize: 16,
+//     fontWeight: '500',
+//   },
+//   content: {
+//     padding: 20,
+//     backgroundColor: '#fff',
+//   },
+//   active: {
+//     backgroundColor: 'rgba(255,255,255,1)',
+//   },
+//   inactive: {
+//     backgroundColor: 'rgba(245,252,255,1)',
+//   },
+//   selectors: {
+//     marginBottom: 10,
+//     flexDirection: 'row',
+//     justifyContent: 'center',
+//   },
+//   selector: {
+//     backgroundColor: '#F5FCFF',
+//     padding: 10,
+//   },
+//   activeSelector: {
+//     fontWeight: 'bold',
+//   },
+//   selectTitle: {
+//     fontSize: 14,
+//     fontWeight: '500',
+//     padding: 10,
+//   },
+//   multipleToggle: {
+//     flexDirection: 'row',
+//     justifyContent: 'center',
+//     marginVertical: 30,
+//     alignItems: 'center',
+//   },
+//   multipleToggle__title: {
+//     fontSize: 16,
+//     marginRight: 8,
+//   },
+// });

--- a/volunta/components/ExpandableInterests.js
+++ b/volunta/components/ExpandableInterests.js
@@ -20,11 +20,12 @@ export default class ExpandableInterest extends Component {
   }
 
   _renderInterests = (numRows, split, passWidths, widths) => {
+    const { activeSections } = this.state;
     return (
       <ProfilePageInterests
         numRows={numRows}
-        collapse={this.collapse}
-        expand={this.expand}
+        collapse={activeSections.length == 1 ? this.collapse : null}
+        expand={activeSections.length == 0 ? this.expand : null}
         split={split}
         sideMargin={SIDE_MARGIN}
         passWidths={passWidths}

--- a/volunta/components/ExpandableInterests.js
+++ b/volunta/components/ExpandableInterests.js
@@ -9,6 +9,7 @@ const SECTIONS = [{}];
 // Used https://github.com/oblador/react-native-collapsible
 // TODO: fetch from db
 // TODO: only expand when (...) is clicked?
+// props: numRows, duration
 export default class ExpandableInterest extends Component {
   constructor(props) {
     super(props);
@@ -22,6 +23,8 @@ export default class ExpandableInterest extends Component {
     return (
       <ProfilePageInterests
         numRows={numRows}
+        collapse={this.collapse}
+        expand={this.expand}
         split={split}
         sideMargin={SIDE_MARGIN}
         passWidths={passWidths}
@@ -43,7 +46,21 @@ export default class ExpandableInterest extends Component {
     );
   };
 
-  // TODO: change 2 to NUM_ROWS
+  collapse = () => {
+    this._updateSections([]);
+  };
+
+  expand = () => {
+    this._updateSections([0]);
+  };
+
+  _updateSections = activeSections => {
+    if (!this.state.loaded) {
+      this.setState({ loaded: !this.state.loaded });
+    }
+    this.setState({ activeSections });
+  };
+
   // TODO: make content clickable to collapse?
 
   passWidths = newWidths => {
@@ -52,9 +69,14 @@ export default class ExpandableInterest extends Component {
 
   _renderHeader = section => {
     if (this.state.activeSections.length == 0) {
-      return this._renderInterests(2, null, this.passWidths, null);
+      return this._renderInterests(
+        this.props.numRows,
+        null,
+        this.passWidths,
+        null
+      );
     } else {
-      return this._renderInterests(null, 2, null, null);
+      return this._renderInterests(null, this.props.numRows, null, null);
     }
   };
 
@@ -62,15 +84,13 @@ export default class ExpandableInterest extends Component {
     if (this.state.activeSections.length == 0 && !this.state.loaded) {
       return this._renderInterests(0, null, null, this.widths);
     } else {
-      return this._renderInterests(null, -2, null, this.widths);
+      return this._renderInterests(
+        null,
+        -this.props.numRows,
+        null,
+        this.widths
+      );
     }
-  };
-
-  _updateSections = activeSections => {
-    if (!this.state.loaded) {
-      this.setState({ loaded: !this.state.loaded });
-    }
-    this.setState({ activeSections });
   };
 
   render() {
@@ -82,9 +102,9 @@ export default class ExpandableInterest extends Component {
         activeSections={this.state.activeSections}
         renderHeader={this._renderHeader}
         renderContent={this._renderContent}
-        onChange={this._updateSections}
+        onChange={activeSections => {}}
         underlayColor={'white'}
-        duration={1000}
+        duration={this.props.duration}
       />
     );
   }

--- a/volunta/components/InterestBubble.js
+++ b/volunta/components/InterestBubble.js
@@ -14,7 +14,6 @@ Props:
 export default class InterestBubble extends React.Component {
   render() {
     const { interestName, marginRight, onLayout, id, onPress } = this.props;
-    console.log(!onPress);
     return (
       <TouchableOpacity onPress={onPress} disabled={!onPress}>
         <View

--- a/volunta/components/InterestBubble.js
+++ b/volunta/components/InterestBubble.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 
 /*
 Interest Bubble Component
@@ -13,14 +13,17 @@ Props:
 */
 export default class InterestBubble extends React.Component {
   render() {
-    const { interestName, marginRight, onLayout, id } = this.props;
+    const { interestName, marginRight, onLayout, id, onPress } = this.props;
+    console.log(!onPress);
     return (
-      <View
-        style={[styles.bubble, { marginRight: marginRight }]}
-        onLayout={!!onLayout ? e => onLayout(e, id) : null}
-      >
-        <Text style={styles.bubbleText}>{interestName}</Text>
-      </View>
+      <TouchableOpacity onPress={onPress} disabled={!onPress}>
+        <View
+          style={[styles.bubble, { marginRight: marginRight }]}
+          onLayout={!!onLayout ? e => onLayout(e, id) : null}
+        >
+          <Text style={styles.bubbleText}>{interestName}</Text>
+        </View>
+      </TouchableOpacity>
     );
   }
 }

--- a/volunta/components/InterestBubble.js
+++ b/volunta/components/InterestBubble.js
@@ -9,18 +9,35 @@ Props:
     - marginRight (optional): margin to add next to bubble, used for spacing
     - onLayout (optional): function that takes event and id, called after bubble is rendered, make sure to pass in id if called.
         Used in bubble component to get bubble width
-    - id (requiered if onLayout is defined): used for identifying bubble in the list its being used. 
+    - id (requiered if onLayout is defined): used for identifying bubble in the list its being used.
+    - onPress: called onPress bubble, if null nothing happens
+    - extraBubbleStyles: extra styles for bubble, overwrites
+    - extraTextStyles: extra styles for bubble text, overwrites
 */
 export default class InterestBubble extends React.Component {
   render() {
-    const { interestName, marginRight, onLayout, id, onPress } = this.props;
+    const {
+      interestName,
+      marginRight,
+      onLayout,
+      id,
+      onPress,
+      extraBubbleStyles,
+      extraTextStyles,
+    } = this.props;
     return (
       <TouchableOpacity onPress={onPress} disabled={!onPress}>
         <View
-          style={[styles.bubble, { marginRight: marginRight }]}
+          style={[
+            styles.bubble,
+            { marginRight: marginRight },
+            extraBubbleStyles,
+          ]}
           onLayout={!!onLayout ? e => onLayout(e, id) : null}
         >
-          <Text style={styles.bubbleText}>{interestName}</Text>
+          <Text style={[styles.bubbleText, extraTextStyles]}>
+            {interestName}
+          </Text>
         </View>
       </TouchableOpacity>
     );
@@ -32,9 +49,14 @@ const styles = StyleSheet.create({
     backgroundColor: '#0081AF',
     alignSelf: 'flex-start',
     borderRadius: 20,
+    borderWidth: 1.5,
+    borderColor: '#0081AF',
+    height: 32,
+    alignItems: 'center',
+    flex: 1,
+    justifyContent: 'center',
   },
   bubbleText: {
-    marginVertical: 7,
     marginHorizontal: 15,
     color: 'white',
     fontFamily: 'montserrat',

--- a/volunta/components/ProfilePageInterests.js
+++ b/volunta/components/ProfilePageInterests.js
@@ -13,6 +13,8 @@ Props:
     - interests: list of strings (interests).
     - passWidths: (optional) functioned passed if parent wants the widths of all bubbles
     - passedWidths: (optional) pass if widths of bubbles are precalculated
+    - collapse: function passed if child of accordion, call to collapse 
+    - expand: function passed if child of accordion, call to expand
 */
 
 const MIN_BUBBLE_SPACING = 7; // Minimum space we want between interest bubbles
@@ -64,7 +66,15 @@ export default class ProfilePageInterests extends React.Component {
   };
 
   render() {
-    const { numRows, sideMargin, split, passWidths, passedWidths } = this.props;
+    const {
+      numRows,
+      sideMargin,
+      split,
+      passWidths,
+      passedWidths,
+      collapse,
+      expand,
+    } = this.props;
     const { readyToShow, widths, interests } = this.state;
 
     // Set widths to passedWidths if they are set, otherwise use from state
@@ -105,9 +115,12 @@ export default class ProfilePageInterests extends React.Component {
       let maxWidth = Dimensions.get('window').width - 2 * sideMargin;
 
       // Push bubble into current row
-      pushBubble = i => {
+      pushBubble = (i, isExtra) => {
         currRow.push(
           <InterestBubble
+            onPress={
+              isExtra ? expand : i == interests.length - 1 ? collapse : null // if its the extra element, we can collapse. If its the last element, it means that we are in full expansion mode, so its made for collapsing.
+            }
             key={i}
             id={i}
             interestName={interests[i]}
@@ -129,7 +142,8 @@ export default class ProfilePageInterests extends React.Component {
         currWidth = 0;
       };
 
-      for (let i = 0; i < interests.length - 1; i++) {
+      num_iters = !!collapse ? interests.length : interests.length - 1; // -1 to ignore the extra element, but add it if collapse option is passed in
+      for (let i = 0; i < num_iters; i++) {
         // We do interests.length-1 since the last object in the array is the '...' (we forced it in)
         w = usedWidths[i];
 
@@ -146,13 +160,13 @@ export default class ProfilePageInterests extends React.Component {
               SIDE_EXTRA_MARGIN >
               maxWidth
           ) {
-            pushBubble(interests.length - 1);
+            pushBubble(interests.length - 1, true);
             pushRow(currRow);
             break;
 
             // Otherwise just push the element
           } else {
-            pushBubble(i);
+            pushBubble(i, false);
           }
         } else {
           // Not on the last row, check if element fits.
@@ -166,7 +180,7 @@ export default class ProfilePageInterests extends React.Component {
           }
 
           // Add to current row
-          pushBubble(i);
+          pushBubble(i, false);
         }
       }
 

--- a/volunta/components/ProfilePageInterests.js
+++ b/volunta/components/ProfilePageInterests.js
@@ -212,9 +212,7 @@ export default class ProfilePageInterests extends React.Component {
       // Convert views from array of arrays to array of views
       views = views.map((row, index) => {
         if (accordionRight && index == 0 && (needExpand || !!collapse)) {
-          accordion = row[0];
-          row[0] = row[row.length - 1];
-          row[row.length - 1] = accordion;
+          row.push(row.shift());
           return (
             <View
               key={index}

--- a/volunta/components/ProfilePageInterests.js
+++ b/volunta/components/ProfilePageInterests.js
@@ -13,15 +13,15 @@ Props:
     - interests: list of strings (interests).
     - passWidths: (optional) functioned passed if parent wants the widths of all bubbles
     - passedWidths: (optional) pass if widths of bubbles are precalculated
-    - collapse: function passed if child of accordion, call to collapse 
-    - expand: function passed if child of accordion, call to expand
+    - collapse: function passed if component is child of accordion and we need to collapse
+    - expand: function passed if component is child of accordion and we need to expand
 */
 
 const MIN_BUBBLE_SPACING = 7; // Minimum space we want between interest bubbles
 const SIDE_EXTRA_MARGIN = 12;
 const MAX_WORD_LENGTH = 20;
 const TRUNCATED_STR_ENDING = '...';
-const ACCORDION = '+'; // first element to expand/collapse...
+const ACCORDION = '+';
 const SHORTENED_LIST_LAST_ITEM = '. . .'; // Add bubble with this string at the end of the list if we shorten it
 
 export default class ProfilePageInterests extends React.Component {
@@ -119,9 +119,7 @@ export default class ProfilePageInterests extends React.Component {
       pushBubble = (i, isExtra) => {
         // Logic to decide if we want to make button pressable
         let onPress = null;
-        if (isExtra) {
-          onPress = expand;
-        } else if (i == 0) {
+        if (i == 0) {
           if (!!expand) {
             onPress = expand;
           } else if (!!collapse) {
@@ -134,11 +132,11 @@ export default class ProfilePageInterests extends React.Component {
             onPress={onPress}
             key={i}
             id={i}
-            expand={i == 0 ? expand : null}
-            collapse={i == 0 ? collapse : null}
-            interestName={interests[i]}
+            interestName={i == 0 ? (!!collapse ? '-' : '+') : interests[i]}
             onLayout={this.onLayoutGetWidth}
             marginRight={MIN_BUBBLE_SPACING}
+            extraTextStyles={i == 0 ? styles.accordionTextStyle : null}
+            extraBubbleStyles={i == 0 ? styles.accordionBubbleStyle : null}
           />
         );
         currWidth += w;
@@ -233,5 +231,16 @@ const styles = StyleSheet.create({
   singleInterestRow: {
     flexDirection: 'row',
     marginVertical: 3,
+  },
+  accordionBubbleStyle: {
+    width: 32,
+    height: 32,
+    backgroundColor: 'white',
+    borderColor: '#0081AF',
+  },
+  accordionTextStyle: {
+    color: '#0081AF',
+    fontSize: 20,
+    marginHorizontal: 0,
   },
 });

--- a/volunta/components/ProfilePageInterests.js
+++ b/volunta/components/ProfilePageInterests.js
@@ -83,7 +83,7 @@ export default class ProfilePageInterests extends React.Component {
         );
       }
       views.push(
-        <View key={0} style={styles.singleInterestRow}>
+        <View key={0} style={[styles.singleInterestRow, { opacity: 0 }]}>
           {currRow}
         </View>
       );

--- a/volunta/components/ProfilePageInterests.js
+++ b/volunta/components/ProfilePageInterests.js
@@ -15,6 +15,7 @@ Props:
     - passedWidths: (optional) pass if widths of bubbles are precalculated
     - collapse: function passed if component is child of accordion and we need to collapse
     - expand: function passed if component is child of accordion and we need to expand
+    - accordionRight: put accordion (+) button on the right instead of on the left
 */
 
 const MIN_BUBBLE_SPACING = 7; // Minimum space we want between interest bubbles
@@ -75,6 +76,7 @@ export default class ProfilePageInterests extends React.Component {
       passedWidths,
       collapse,
       expand,
+      accordionRight,
     } = this.props;
     const { readyToShow, widths, interests } = this.state;
 
@@ -206,14 +208,35 @@ export default class ProfilePageInterests extends React.Component {
           views[0] = views[0].slice(1, views[0].length);
         }
       }
-    }
 
-    // Convert views from array of arrays to array of views
-    views = views.map((row, index) => (
-      <View key={index} style={styles.singleInterestRow}>
-        {row}
-      </View>
-    ));
+      // Convert views from array of arrays to array of views
+      views = views.map((row, index) => {
+        if (accordionRight && index == 0 && (needExpand || !!collapse)) {
+          accordion = row[0];
+          row[0] = row[row.length - 1];
+          row[row.length - 1] = accordion;
+          return (
+            <View
+              key={index}
+              flexDirection={'row'}
+              justifyContent={'space-between'}
+            >
+              <View style={styles.singleInterestRow}>
+                {row.slice(0, row.length - 1)}
+              </View>
+              <View style={styles.singleInterestRow}>
+                {row[row.length - 1]}
+              </View>
+            </View>
+          );
+        }
+        return (
+          <View key={index} style={styles.singleInterestRow}>
+            {row}
+          </View>
+        );
+      });
+    }
 
     if (!!split) {
       if (split > 0) {

--- a/volunta/package-lock.json
+++ b/volunta/package-lock.json
@@ -4285,24 +4285,24 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "optional": true,
           "requires": {
@@ -4312,12 +4312,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+          "resolved": false,
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
@@ -4326,34 +4326,34 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+          "resolved": false,
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
           "optional": true
         },
         "debug": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
           "optional": true,
           "requires": {
@@ -4362,25 +4362,25 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "resolved": false,
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
+          "resolved": false,
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "optional": true,
           "requires": {
@@ -4389,13 +4389,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+          "resolved": false,
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "optional": true,
           "requires": {
@@ -4411,7 +4411,7 @@
         },
         "glob": {
           "version": "7.1.3",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+          "resolved": false,
           "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
           "optional": true,
           "requires": {
@@ -4425,13 +4425,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+          "resolved": false,
           "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
           "optional": true,
           "requires": {
@@ -4440,7 +4440,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "optional": true,
           "requires": {
@@ -4449,7 +4449,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "optional": true,
           "requires": {
@@ -4459,18 +4459,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "resolved": false,
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -4478,13 +4478,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+          "resolved": false,
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -4492,12 +4492,12 @@
         },
         "minimist": {
           "version": "0.0.8",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "resolved": false,
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
+          "resolved": false,
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -4506,7 +4506,7 @@
         },
         "minizlib": {
           "version": "1.2.1",
-          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.2.1.tgz",
+          "resolved": false,
           "integrity": "sha512-7+4oTUOWKg7AuL3vloEWekXY2/D20cevzsrNT2kGWm+39J9hGTCBv8VI5Pm5lXZ/o3/mdR4f8rflAPhnQb8mPA==",
           "optional": true,
           "requires": {
@@ -4515,7 +4515,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "resolved": false,
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -4523,13 +4523,13 @@
         },
         "ms": {
           "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
           "optional": true
         },
         "needle": {
           "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/needle/-/needle-2.3.0.tgz",
+          "resolved": false,
           "integrity": "sha512-QBZu7aAFR0522EyaXZM0FZ9GLpq6lvQ3uq8gteiDUp7wKdy0lSd2hPlgFwVuW1CBkfEs9PfDQsQzZghLs/psdg==",
           "optional": true,
           "requires": {
@@ -4540,7 +4540,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
+          "resolved": false,
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "optional": true,
           "requires": {
@@ -4558,7 +4558,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "optional": true,
           "requires": {
@@ -4568,13 +4568,13 @@
         },
         "npm-bundled": {
           "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.6.tgz",
+          "resolved": false,
           "integrity": "sha512-8/JCaftHwbd//k6y2rEWp6k1wxVfpFzB6t1p825+cUb7Ym2XQfhwIC5KwhrvzZRJu+LtDE585zVaS32+CGtf0g==",
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.4.1.tgz",
+          "resolved": false,
           "integrity": "sha512-+TcdO7HJJ8peiiYhvPxsEDhF3PJFGUGRcFsGve3vxvxdcpO2Z4Z7rkosRM0kWj6LfbK/P0gu3dzk5RU1ffvFcw==",
           "optional": true,
           "requires": {
@@ -4584,7 +4584,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "optional": true,
           "requires": {
@@ -4596,18 +4596,18 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+          "resolved": false,
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+          "resolved": false,
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
@@ -4615,19 +4615,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
+          "resolved": false,
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "optional": true,
           "requires": {
@@ -4637,19 +4637,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "resolved": false,
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "optional": true,
           "requires": {
@@ -4661,7 +4661,7 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+              "resolved": false,
               "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
               "optional": true
             }
@@ -4669,7 +4669,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+          "resolved": false,
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "optional": true,
           "requires": {
@@ -4684,7 +4684,7 @@
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": false,
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "optional": true,
           "requires": {
@@ -4693,42 +4693,42 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+          "resolved": false,
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
+          "resolved": false,
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
           "optional": true
         },
         "semver": {
           "version": "5.7.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+          "resolved": false,
           "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+          "resolved": false,
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -4738,7 +4738,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+          "resolved": false,
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "optional": true,
           "requires": {
@@ -4747,7 +4747,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -4755,13 +4755,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "resolved": false,
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
           "optional": true
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
+          "resolved": false,
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "optional": true,
           "requires": {
@@ -4776,13 +4776,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+          "resolved": false,
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "optional": true,
           "requires": {
@@ -4791,12 +4791,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+          "resolved": false,
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "resolved": false,
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
@@ -4911,22 +4911,22 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
           "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
           "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
           "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
           "requires": {
             "delegates": "^1.0.0",
@@ -4935,12 +4935,12 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
           "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
           "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
           "requires": {
             "balanced-match": "^1.0.0",
@@ -4949,32 +4949,32 @@
         },
         "chownr": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
           "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g=="
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
           "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
           "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
           "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
           "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "debug": {
           "version": "2.6.9",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
@@ -4982,22 +4982,22 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
           "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
           "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
           "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
         },
         "fs-minipass": {
           "version": "1.2.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.5.tgz",
           "integrity": "sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==",
           "requires": {
             "minipass": "^2.2.1"
@@ -5005,12 +5005,12 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
           "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
           "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
           "requires": {
             "aproba": "^1.0.3",
@@ -5025,7 +5025,7 @@
         },
         "glob": {
           "version": "7.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
           "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
           "requires": {
             "fs.realpath": "^1.0.0",
@@ -5038,12 +5038,12 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
           "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
         },
         "iconv-lite": {
           "version": "0.4.23",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
           "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -5051,7 +5051,7 @@
         },
         "ignore-walk": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ignore-walk/-/ignore-walk-3.0.1.tgz",
           "integrity": "sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==",
           "requires": {
             "minimatch": "^3.0.4"
@@ -5059,7 +5059,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
           "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
           "requires": {
             "once": "^1.3.0",
@@ -5068,17 +5068,17 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
           "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
           "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "requires": {
             "number-is-nan": "^1.0.0"
@@ -5086,12 +5086,12 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
           "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
           "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
           "requires": {
             "brace-expansion": "^1.1.7"
@@ -5099,12 +5099,12 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "minipass": {
           "version": "2.3.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
           "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
           "requires": {
             "safe-buffer": "^5.1.2",
@@ -5113,7 +5113,7 @@
         },
         "minizlib": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-1.1.1.tgz",
           "integrity": "sha512-TrfjCjk4jLhcJyGMYymBH6oTXcWjYbUAXTHDbtnWHjZC25h0cdajHuPE1zxb4DVmu8crfh+HwH/WMuyLG0nHBg==",
           "requires": {
             "minipass": "^2.2.1"
@@ -5121,7 +5121,7 @@
         },
         "mkdirp": {
           "version": "0.5.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
           "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
           "requires": {
             "minimist": "0.0.8"
@@ -5129,19 +5129,19 @@
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
-              "resolved": false,
+              "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
               "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
             }
           }
         },
         "ms": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
           "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "needle": {
           "version": "2.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/needle/-/needle-2.2.4.tgz",
           "integrity": "sha512-HyoqEb4wr/rsoaIDfTH2aVL9nWtQqba2/HvMv+++m8u0dz808MaagKILxtfeSN7QU7nvbQ79zk3vYOJp9zsNEA==",
           "requires": {
             "debug": "^2.1.2",
@@ -5151,7 +5151,7 @@
         },
         "node-pre-gyp": {
           "version": "0.12.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/node-pre-gyp/-/node-pre-gyp-0.12.0.tgz",
           "integrity": "sha512-4KghwV8vH5k+g2ylT+sLTjy5wmUOb9vPhnM8NHvRf9dHmnW/CndrFXy2aRPaPST6dugXSdHXfeaHQm77PIz/1A==",
           "requires": {
             "detect-libc": "^1.0.2",
@@ -5168,7 +5168,7 @@
         },
         "nopt": {
           "version": "4.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
           "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
           "requires": {
             "abbrev": "1",
@@ -5177,12 +5177,12 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-bundled/-/npm-bundled-1.0.5.tgz",
           "integrity": "sha512-m/e6jgWu8/v5niCUKQi9qQl8QdeEduFA96xHDDzFGqly0OOjI7c+60KM/2sppfnUU9JJagf+zs+yGhqSOFj71g=="
         },
         "npm-packlist": {
           "version": "1.1.12",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npm-packlist/-/npm-packlist-1.1.12.tgz",
           "integrity": "sha512-WJKFOVMeAlsU/pjXuqVdzU0WfgtIBCupkEVwn+1Y0ERAbUfWw8R4GjgVbaKnUjRoD2FoQbHOCbOyT5Mbs9Lw4g==",
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -5191,7 +5191,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
           "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
           "requires": {
             "are-we-there-yet": "~1.1.2",
@@ -5202,17 +5202,17 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
           "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
           "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
           "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
           "requires": {
             "wrappy": "1"
@@ -5220,17 +5220,17 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
           "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
           "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
           "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
           "requires": {
             "os-homedir": "^1.0.0",
@@ -5239,17 +5239,17 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
           "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
           "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw=="
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
           "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
           "requires": {
             "deep-extend": "^0.6.0",
@@ -5260,7 +5260,7 @@
         },
         "readable-stream": {
           "version": "2.3.6",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
           "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
           "requires": {
             "core-util-is": "~1.0.0",
@@ -5274,7 +5274,7 @@
         },
         "rimraf": {
           "version": "2.6.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
           "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
           "requires": {
             "glob": "^7.0.5"
@@ -5282,37 +5282,37 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
           "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
           "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
           "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
         },
         "semver": {
           "version": "5.6.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
           "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
           "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
           "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "requires": {
             "code-point-at": "^1.0.0",
@@ -5322,7 +5322,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
           "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
           "requires": {
             "safe-buffer": "~5.1.0"
@@ -5330,7 +5330,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "requires": {
             "ansi-regex": "^2.0.0"
@@ -5338,12 +5338,12 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         },
         "tar": {
           "version": "4.4.8",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/tar/-/tar-4.4.8.tgz",
           "integrity": "sha512-LzHF64s5chPQQS0IYBn9IN5h3i98c12bo4NCO7e0sGM2llXQ3p2FGC5sdENN4cTW48O915Sh+x+EXx7XW96xYQ==",
           "requires": {
             "chownr": "^1.1.1",
@@ -5357,12 +5357,12 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
           "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
           "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
           "requires": {
             "string-width": "^1.0.2 || 2"
@@ -5370,12 +5370,12 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
           "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
         },
         "yallist": {
           "version": "3.0.3",
-          "resolved": false,
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
           "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
         }
       }
@@ -8679,6 +8679,14 @@
       "version": "2.2.5",
       "resolved": "https://registry.npmjs.org/react-native-branch/-/react-native-branch-2.2.5.tgz",
       "integrity": "sha1-QHTdY7SXPmOX2c5Q6XtXx3pRjp0="
+    },
+    "react-native-collapsible": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-native-collapsible/-/react-native-collapsible-1.4.0.tgz",
+      "integrity": "sha512-lf2U3gRHTNakqtN04NLJkmF02XaOF/DPOTGlwK8yrn85wMAdRaPpD0fnb7RvH4OID3SmxXBTWzZqkBTmasJyIQ==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
     },
     "react-native-datepicker": {
       "version": "1.7.2",

--- a/volunta/package.json
+++ b/volunta/package.json
@@ -18,6 +18,7 @@
     "material-ui-community-icons": "^0.15.0",
     "react": "16.5.0",
     "react-native": "https://github.com/expo/react-native/archive/sdk-32.0.0.tar.gz",
+    "react-native-collapsible": "^1.4.0",
     "react-native-datepicker": "^1.7.2",
     "react-native-elements": "^1.1.0",
     "react-native-swipeout": "^2.3.6",

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -137,23 +137,6 @@ export default class ProfileScreen extends React.Component {
           </View>
           <View style={styles.interestBar}>
             <Text style={styles.sectionTitle}>interests:</Text>
-            {/* <ProfilePageInterests
-              numRows={2}
-              sideMargin={SIDE_MARGIN}
-              interests={[
-                'public health',
-                'public',
-                'social good',
-                'really long interest that I love',
-                'kids',
-                'civics',
-                'environmental',
-                'beach',
-                'kids',
-                'health things',
-                'words',
-              ]}
-            /> */}
             <ExpandableInterests duration={1000} numRows={2} />
           </View>
           <View style={styles.comingUpBar}>

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -154,7 +154,7 @@ export default class ProfileScreen extends React.Component {
                 'words',
               ]}
             /> */}
-            <ExpandableInterests />
+            <ExpandableInterests duration={1000} numRows={2} />
           </View>
           <View style={styles.comingUpBar}>
             <Text style={styles.sectionTitle}>coming up:</Text>

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -24,8 +24,6 @@ import * as firebase from 'firebase';
 
 const SIDE_MARGIN = 20;
 
-const SIDE_MARGIN = 20;
-
 export default class ProfileScreen extends React.Component {
   constructor(props) {
     super(props);
@@ -87,17 +85,19 @@ export default class ProfileScreen extends React.Component {
   };
 
   _onPressSettings = () => {
-    ActionSheetIOS.showActionSheetWithOptions({
-      options: ['Cancel', 'Logout', 'Edit Profile'],
-      destructiveButtonIndex: 1,
-      cancelButtonIndex: 0,
-    },
-    (buttonIndex) => {
-      if (buttonIndex === 1) {
-        firebase.auth().signOut();
+    ActionSheetIOS.showActionSheetWithOptions(
+      {
+        options: ['Cancel', 'Logout', 'Edit Profile'],
+        destructiveButtonIndex: 1,
+        cancelButtonIndex: 0,
+      },
+      buttonIndex => {
+        if (buttonIndex === 1) {
+          firebase.auth().signOut();
+        }
       }
-    },);
-  }
+    );
+  };
 
   render() {
     const {
@@ -127,7 +127,10 @@ export default class ProfileScreen extends React.Component {
               <Text style={styles.personName}>Kanye West</Text>
               <Text style={styles.communityName}>Stanford University</Text>
             </View>
-            <TouchableOpacity onPress={this._onPressSettings} style={styles.editIcon}>
+            <TouchableOpacity
+              onPress={this._onPressSettings}
+              style={styles.editIcon}
+            >
               <Ionicons name="ios-settings" size={30} color="#0081AF" />
             </TouchableOpacity>
           </View>

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -11,6 +11,7 @@ import {
 } from 'react-native';
 import Facepile from '../components/Facepile';
 import ProfilePageInterests from '../components/ProfilePageInterests';
+import ExpandableInterests from '../components/ExpandableInterests';
 import CommunityProfileEventCardHorizontalScroll from '../components/CommunityProfileEventCardHorizontalScroll';
 import Ionicons from '@expo/vector-icons/Ionicons';
 import {
@@ -136,7 +137,7 @@ export default class ProfileScreen extends React.Component {
           </View>
           <View style={styles.interestBar}>
             <Text style={styles.sectionTitle}>interests:</Text>
-            <ProfilePageInterests
+            {/* <ProfilePageInterests
               numRows={2}
               sideMargin={SIDE_MARGIN}
               interests={[
@@ -152,7 +153,8 @@ export default class ProfileScreen extends React.Component {
                 'health things',
                 'words',
               ]}
-            />
+            /> */}
+            <ExpandableInterests />
           </View>
           <View style={styles.comingUpBar}>
             <Text style={styles.sectionTitle}>coming up:</Text>

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -137,7 +137,7 @@ export default class ProfileScreen extends React.Component {
           </View>
           <View style={styles.interestBar}>
             <Text style={styles.sectionTitle}>interests:</Text>
-            <ExpandableInterests duration={1000} numRows={2} />
+            <ExpandableInterests duration={500} numRows={2} />
           </View>
           <View style={styles.comingUpBar}>
             <Text style={styles.sectionTitle}>coming up:</Text>

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -137,7 +137,11 @@ export default class ProfileScreen extends React.Component {
           </View>
           <View style={styles.interestBar}>
             <Text style={styles.sectionTitle}>interests:</Text>
-            <ExpandableInterests duration={500} numRows={2} />
+            <ExpandableInterests
+              duration={500}
+              numRows={2}
+              accordionRight={true}
+            />
           </View>
           <View style={styles.comingUpBar}>
             <Text style={styles.sectionTitle}>coming up:</Text>


### PR DESCRIPTION
Fixes #87 

Expands on previews PR. Now when the (...) shows up, we also add a clickable (+) sign to expand and see all the bubbles. 

The button can be put on the right side of the first row if specified by a prop. 

There is a lot of logic to this. We use an Accordion component. When we collapse, we use the header for the collapsed view and then the content for the expanded view (extra bubbles in the content).

One small thing is that it might look weird depending on the sizes when the rows are not collapsed, since I remove the ( + ), but that was considered to be taking space so there might be some unused space. I shouldn't be too bad though and based on how the logic for the bubbles work its a pretty hard fix, not worth it for now. 

TODO: add database integration

See [video](https://vimeo.com/user98677825/review/337029197/5678d80ba1)

Rows collapsed (left):

<img width="353" alt="Screenshot 2019-05-18 12 21 16" src="https://user-images.githubusercontent.com/26133102/57974239-ced36c00-7969-11e9-9190-a3f45857a4f5.png">

Rows collapsed (right):

<img width="345" alt="Screenshot 2019-05-18 13 19 24" src="https://user-images.githubusercontent.com/26133102/57974649-ba46a200-7970-11e9-90f2-ac92abb2ad7f.png">

When rows not collapsed: 

<img width="345" alt="Screenshot 2019-05-18 12 21 48" src="https://user-images.githubusercontent.com/26133102/57974237-c5e29a80-7969-11e9-8e91-e6b0eff6c643.png">



