### PR TITLE
NUXInterestsScreen for choosing initial interests

### DIFF
--- a/volunta/components/InterestSquare.js
+++ b/volunta/components/InterestSquare.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
+
+/*
+Interest Square Component used in NUXInterestsScreen
+
+Props:
+    - interestName: name for interest
+    - selected: whether or not the interest is selected
+*/
+export default class InterestSquare extends React.Component {
+  render() {
+    const { interestName, selected } = this.props;
+    return (
+      <TouchableOpacity style={styles.separator}>
+        <View
+          style={[
+            styles.bubble,
+            { backgroundColor: selected ? '#0081AF' : '#F2F2F2' },
+          ]}
+        >
+          <Text
+            style={[styles.bubbleText, { color: selected ? 'white' : 'black' }]}
+          >
+            {interestName}
+          </Text>
+        </View>
+      </TouchableOpacity>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  bubble: {
+    alignSelf: 'flex-start',
+    borderRadius: 8,
+    height: 36,
+    width: 138,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  bubbleText: {
+    marginHorizontal: 15,
+    fontFamily: 'montserrat',
+    fontSize: 14,
+  },
+  separator: {
+    marginRight: 10,
+    marginLeft: 10,
+  },
+});

--- a/volunta/components/InterestSquare.js
+++ b/volunta/components/InterestSquare.js
@@ -6,13 +6,33 @@ Interest Square Component used in NUXInterestsScreen
 
 Props:
     - interestName: name for interest
-    - selected: whether or not the interest is selected
+    - updateParentInterestsMap: function to update NUXInterestsScreen state map
 */
 export default class InterestSquare extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      selected: false,
+    };
+  }
+
+  _onPressInterest = () => {
+    const prevSelected = this.state.selected;
+    this.setState({
+      selected: !prevSelected,
+    });
+    this.props.updateParentInterestsMap(this.props.interestName, !prevSelected);
+  };
+
   render() {
-    const { interestName, selected } = this.props;
+    const { interestName } = this.props;
+    const { selected } = this.state;
     return (
-      <TouchableOpacity style={styles.separator}>
+      <TouchableOpacity
+        style={styles.separator}
+        onPress={this._onPressInterest}
+      >
         <View
           style={[
             styles.bubble,

--- a/volunta/firebase/api.js
+++ b/volunta/firebase/api.js
@@ -549,3 +549,18 @@ export const getUserInterestNames = async userDocId => {
     })
   );
 };
+
+// Returns a list of all interest names
+export const getAllInterestNames = async () => {
+  var communities = [];
+  await firestore
+    .collection('interests')
+    .get()
+    .then(snapshot => {
+      snapshot.forEach(communityRef => {
+        let name = communityRef.get('name');
+        communities.push(name);
+      });
+    });
+  return communities;
+};

--- a/volunta/firebase/api.js
+++ b/volunta/firebase/api.js
@@ -553,16 +553,16 @@ export const getUserInterestNames = async userDocId => {
 
 // Returns a list of all interest names
 export const getAllInterestNames = async () => {
-  var communities = [];
+  var interests = [];
   await firestore
     .collection('interests')
     .orderBy('name')
     .get()
     .then(snapshot => {
-      snapshot.forEach(communityRef => {
-        let name = communityRef.get('name');
-        communities.push(name);
+      snapshot.forEach(interestRef => {
+        let name = interestRef.get('name');
+        interests.push(name);
       });
     });
-  return communities;
+  return interests;
 };

--- a/volunta/firebase/api.js
+++ b/volunta/firebase/api.js
@@ -542,12 +542,13 @@ export const getUserInterestNames = async userDocId => {
     .then(snapshot => {
       interestRefs = snapshot.get('interest_refs');
     });
-  return await Promise.all(
+  interestRefs = await Promise.all(
     interestRefs.map(async interestRef => {
       var interestSnapshot = await interestRef.get();
       return interestSnapshot.get('name');
     })
   );
+  return interestRefs.sort();
 };
 
 // Returns a list of all interest names
@@ -555,6 +556,7 @@ export const getAllInterestNames = async () => {
   var communities = [];
   await firestore
     .collection('interests')
+    .orderBy('name')
     .get()
     .then(snapshot => {
       snapshot.forEach(communityRef => {

--- a/volunta/navigation/MainTabNavigator.js
+++ b/volunta/navigation/MainTabNavigator.js
@@ -16,7 +16,7 @@ import Facepile from '../components/Facepile';
 import NUXInterestsScreen from '../screens/NUXInterestsScreen';
 
 const FeedStack = createStackNavigator({
-  Feed: NUXInterestsScreen,
+  Feed: FeedScreen,
   Event: EventScreen,
   Facepile: FacepileDetailScreen,
   Profile: ProfileScreen,

--- a/volunta/navigation/MainTabNavigator.js
+++ b/volunta/navigation/MainTabNavigator.js
@@ -13,9 +13,10 @@ import NotificationsScreen from '../screens/NotificationsScreen';
 import EventScreen from '../screens/EventScreen';
 import FacepileDetailScreen from '../screens/FacepileDetailScreen';
 import Facepile from '../components/Facepile';
+import NUXInterestsScreen from '../screens/NUXInterestsScreen';
 
 const FeedStack = createStackNavigator({
-  Feed: FeedScreen,
+  Feed: NUXInterestsScreen,
   Event: EventScreen,
   Facepile: FacepileDetailScreen,
   Profile: ProfileScreen,

--- a/volunta/screens/NUXInterestsScreen.js
+++ b/volunta/screens/NUXInterestsScreen.js
@@ -40,7 +40,6 @@ export default class NUXInterestsScreen extends React.Component {
 
   _updateInterestsMap = (interestName, selected) => {
     var interestsMap = this.state.interestsMap;
-    console.log(selected);
     interestsMap = interestsMap.set(interestName, selected);
     this.setState({
       interestsMap,
@@ -58,8 +57,8 @@ export default class NUXInterestsScreen extends React.Component {
   };
 
   // TODO: Save interests set to true in interestsMap to current user's interests in db
-  _onPressDone = event => {
-    this.props.navigation.navigate('Main');
+  _onPressDone = () => {
+    this.props.navigation.navigate('Feed');
   };
 
   _renderSeparator = () => {
@@ -74,7 +73,6 @@ export default class NUXInterestsScreen extends React.Component {
 
   render() {
     const { interests, interestsMap } = this.state;
-    console.log(interestsMap);
     return (
       <View style={styles.container}>
         <Text style={styles.headerText}>what are your interests?</Text>

--- a/volunta/screens/NUXInterestsScreen.js
+++ b/volunta/screens/NUXInterestsScreen.js
@@ -27,7 +27,7 @@ export default class NUXInterestsScreen extends React.Component {
   _loadData = async () => {
     const interests = await getAllInterestNames();
     var interestsMap = new Map();
-    // Map all interests to false (not selected) at first
+    // Map all interests to false (i.e. not selected) at first
     interests.forEach(interest => {
       interestsMap.set(interest, false);
     });
@@ -38,20 +38,26 @@ export default class NUXInterestsScreen extends React.Component {
     });
   };
 
-  _onPressInterest = interestName => {
+  _updateInterestsMap = (interestName, selected) => {
     var interestsMap = this.state.interestsMap;
-    var currentState = interestsMap.get(interestName);
-    interestsMap.set(interestName, !currentState);
+    console.log(selected);
+    interestsMap = interestsMap.set(interestName, selected);
     this.setState({
       interestsMap,
     });
   };
 
   _renderInterestSquare = ({ item }) => {
-    return <InterestSquare interestName={item} />;
+    return (
+      <InterestSquare
+        interestName={item}
+        // Bind 'this' to update the state of the parent from the child
+        updateParentInterestsMap={this._updateInterestsMap.bind(this)}
+      />
+    );
   };
 
-  // Function we pass to Log In button, pushes login screen onto stack
+  // TODO: Save interests set to true in interestsMap to current user's interests in db
   _onPressDone = event => {
     this.props.navigation.navigate('Main');
   };
@@ -68,6 +74,7 @@ export default class NUXInterestsScreen extends React.Component {
 
   render() {
     const { interests, interestsMap } = this.state;
+    console.log(interestsMap);
     return (
       <View style={styles.container}>
         <Text style={styles.headerText}>what are your interests?</Text>
@@ -88,7 +95,7 @@ export default class NUXInterestsScreen extends React.Component {
             ItemSeparatorComponent={this._renderSeparator}
           />
         </View>
-        <TouchableOpacity>
+        <TouchableOpacity onPress={this._onPressDone}>
           <View style={styles.button}>
             <Text style={styles.buttonText}>done</Text>
           </View>

--- a/volunta/screens/NUXInterestsScreen.js
+++ b/volunta/screens/NUXInterestsScreen.js
@@ -5,30 +5,94 @@ import {
   Text,
   TouchableOpacity,
   View,
+  FlatList,
 } from 'react-native';
+import { getAllInterestNames } from '../firebase/api';
+import InterestSquare from '../components/InterestSquare';
 
 export default class NUXInterestsScreen extends React.Component {
-
   constructor(props) {
     super(props);
+
+    this.state = {
+      interests: [],
+      interestsMap: new Map(),
+    };
   }
+
+  async componentDidMount() {
+    this._loadData();
+  }
+
+  _loadData = async () => {
+    const interests = await getAllInterestNames();
+    var interestsMap = new Map();
+    // Map all interests to false (not selected) at first
+    interests.forEach(interest => {
+      interestsMap.set(interest, false);
+    });
+
+    this.setState({
+      interests,
+      interestsMap,
+    });
+  };
+
+  _onPressInterest = interestName => {
+    var interestsMap = this.state.interestsMap;
+    var currentState = interestsMap.get(interestName);
+    interestsMap.set(interestName, !currentState);
+    this.setState({
+      interestsMap,
+    });
+  };
+
+  _renderInterestSquare = ({ item }) => {
+    return <InterestSquare interestName={item} />;
+  };
 
   // Function we pass to Log In button, pushes login screen onto stack
   _onPressDone = event => {
-    this.props.navigation.navigate('Main')
+    this.props.navigation.navigate('Main');
+  };
+
+  _renderSeparator = () => {
+    return (
+      <View
+        style={{
+          marginVertical: 10,
+        }}
+      />
+    );
   };
 
   render() {
+    const { interests, interestsMap } = this.state;
     return (
       <View style={styles.container}>
-        <Text>What are your interests?</Text>
-        <View>
-          <TouchableOpacity onPress={this._onPressContinue}>
-            <View style={styles.button}>
-              <Text style={styles.buttonText}>done</Text>
-            </View>
-          </TouchableOpacity>
+        <Text style={styles.headerText}>what are your interests?</Text>
+        <View style={styles.textContainer}>
+          <Text style={styles.detailText}>
+            These interests will be displayed on your profile to let other
+            volunteers get to know you, and they can help you filter searches
+            for service events.
+          </Text>
         </View>
+
+        <View style={styles.interestsGrid}>
+          <FlatList
+            data={interests}
+            renderItem={this._renderInterestSquare}
+            keyExtractor={(_, index) => index.toString()}
+            numColumns={2}
+            ItemSeparatorComponent={this._renderSeparator}
+          />
+        </View>
+        <TouchableOpacity>
+          <View style={styles.button}>
+            <Text style={styles.buttonText}>done</Text>
+          </View>
+        </TouchableOpacity>
       </View>
     );
   }
@@ -41,19 +105,35 @@ const styles = StyleSheet.create({
     borderRadius: 15,
     height: 46,
     justifyContent: 'center',
-    marginTop: 20,
     width: 202,
   },
   buttonText: {
-    color: "#FFFFFF",
+    color: '#FFFFFF',
     fontFamily: 'montserrat',
     fontSize: 18,
     fontWeight: 'normal',
   },
   container: {
     alignItems: 'center',
-    flex: 1,
     backgroundColor: '#fff',
-    justifyContent: 'center',
+    marginHorizontal: 10,
+  },
+  textContainer: {
+    marginHorizontal: 40,
+  },
+  headerText: {
+    fontFamily: 'montserrat-medium',
+    fontSize: 22,
+    marginTop: 40,
+  },
+  detailText: {
+    textAlign: 'center',
+    fontFamily: 'montserrat',
+    fontSize: 15,
+    marginTop: 30,
+  },
+  interestsGrid: {
+    marginTop: 30,
+    height: 370,
   },
 });

--- a/volunta/screens/NUXInterestsScreen.js
+++ b/volunta/screens/NUXInterestsScreen.js
@@ -111,6 +111,7 @@ const styles = StyleSheet.create({
     height: 46,
     justifyContent: 'center',
     width: 202,
+    marginTop: 30,
   },
   buttonText: {
     color: '#FFFFFF',
@@ -139,6 +140,6 @@ const styles = StyleSheet.create({
   },
   interestsGrid: {
     marginTop: 30,
-    height: 370,
+    height: 350,
   },
 });


### PR DESCRIPTION
Built out the NUXInterestsScreen with a FlatList of new InterestSquare components. Successfully saves all of the toggled-on interests into the screen's state. For now, done just navigates to feed, but we need to edit to push the saved interests to the current user's entry in db soon.

Also sorted interests alphabetically and did the same for getting user interests for profile for consistency.

No entry point right now, but will be after NUXCommunityScreen during registration.

Fixes #77 