### PR TITLE
Profile bugs + profile UI

### DIFF
--- a/volunta/components/EventPageHeader.js
+++ b/volunta/components/EventPageHeader.js
@@ -70,8 +70,8 @@ const styles = StyleSheet.create({
     height: 74,
     borderRadius: 37,
     marginRight: 15,
-    marginBottom: 0,
     marginTop: 15,
+    marginLeft: 10,
     alignSelf: 'center',
   },
   headerText: {

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -422,5 +422,6 @@ const styles = StyleSheet.create({
   },
   facepileContainer: {
     marginTop: 28,
+    marginBottom: 10,
   },
 });

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -47,6 +47,7 @@ export default class ProfileScreen extends React.Component {
       interests: [],
       profilePic: null,
       profilePicIsBase64: null,
+      isCurrentUser: false,
     };
   }
 
@@ -65,6 +66,9 @@ export default class ProfileScreen extends React.Component {
     // TODO: Change default to current user
     let currentUserId = await firebase.auth().currentUser.uid;
     const userId = this.props.navigation.getParam('userId', currentUserId);
+    if (userId == currentUserId) {
+      this.setState({ isCurrentUser: true });
+    }
     const [
       [upcomingEvents, pastEvents, ongoingEvents],
       interests,
@@ -236,6 +240,7 @@ export default class ProfileScreen extends React.Component {
       interests,
       profilePic,
       profilePicIsBase64,
+      isCurrentUser,
     } = this.state;
     const hidePastEvents = pastEvents.length == 0;
 
@@ -255,7 +260,10 @@ export default class ProfileScreen extends React.Component {
         >
           <View style={styles.container}>
             <View style={styles.profileBar}>
-              <TouchableOpacity onPress={this._onPressProfilePic}>
+              <TouchableOpacity
+                onPress={this._onPressProfilePic}
+                disabled={!isCurrentUser}
+              >
                 <Image style={styles.profilePic} source={{ uri: img_uri }} />
               </TouchableOpacity>
               <View style={styles.upperText}>

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -10,6 +10,7 @@ import {
   RefreshControl,
   ActivityIndicator,
   AlertIOS,
+  Dimensions,
 } from 'react-native';
 import Facepile from '../components/Facepile';
 import ExpandableInterests from '../components/ExpandableInterests';
@@ -258,29 +259,29 @@ export default class ProfileScreen extends React.Component {
             />
           }
         >
-          <View style={styles.container}>
-            <View style={styles.profileBar}>
-              <TouchableOpacity
-                onPress={this._onPressProfilePic}
-                disabled={!isCurrentUser}
-              >
-                <Image style={styles.profilePic} source={{ uri: img_uri }} />
-              </TouchableOpacity>
-              <View style={styles.upperText}>
-                <Text style={styles.personName}>{this.state.profileName}</Text>
-                <Text style={styles.communityName}>
-                  {this.state.communityName}
-                </Text>
-              </View>
-              <TouchableOpacity
-                onPress={this._onPressSettings}
-                style={[styles.editIcon, { width: isCurrentUser ? 30 : 0 }]}
-              >
-                <Ionicons name="ios-settings" size={30} color="#0081AF" />
-              </TouchableOpacity>
+          <View style={styles.profileBar}>
+            <TouchableOpacity
+              onPress={this._onPressProfilePic}
+              disabled={!isCurrentUser}
+            >
+              <Image style={styles.profilePic} source={{ uri: img_uri }} />
+            </TouchableOpacity>
+            <View style={styles.upperText}>
+              <Text style={styles.personName}>{this.state.profileName}</Text>
+              <Text style={styles.communityName}>
+                {this.state.communityName}
+              </Text>
             </View>
+            <TouchableOpacity
+              onPress={this._onPressSettings}
+              style={[styles.editIcon, { width: isCurrentUser ? 30 : 0 }]}
+            >
+              <Ionicons name="ios-settings" size={30} color="#0081AF" />
+            </TouchableOpacity>
+          </View>
+          <View style={styles.container}>
             <View style={styles.interestBar}>
-              <Text style={styles.sectionTitle}>interests:</Text>
+              <Text style={styles.sectionTitle}>interests</Text>
               {interests.length > 0 && (
                 <ExpandableInterests
                   interests={interests}
@@ -291,8 +292,8 @@ export default class ProfileScreen extends React.Component {
               )}
             </View>
             <View style={styles.comingUpBar}>
-              <Text style={styles.sectionTitle}>coming up:</Text>
-              <View style={styles.upcomingScroll}>
+              <Text style={styles.sectionTitle}>coming up</Text>
+              <View style={styles.scroll}>
                 <CommunityProfileEventCardHorizontalScroll
                   events={upcomingEvents}
                   interestedIDs={interestedEventDocIds}
@@ -303,23 +304,21 @@ export default class ProfileScreen extends React.Component {
                 />
               </View>
             </View>
-            <View
-              style={[styles.helpedBar, { height: hidePastEvents ? 0 : 160 }]}
-            >
-              <Text style={styles.helpedTitle}>how I've helped:</Text>
-              <CommunityProfileEventCardHorizontalScroll
-                events={pastEvents}
-                interestedIDs={interestedEventDocIds}
-                onPress={this._onPressOpenEventPage}
-                goingIDs={goingEventDocIds}
-                status={'past'}
-                source={'profile'}
-              />
-            </View>
-            <View>
-              <Text style={styles.sectionTitle}>volunteer network:</Text>
+            <View style={hidePastEvents ? { height: 0 } : styles.helpedBar}>
+              <Text style={styles.sectionTitle}>how I've helped</Text>
+              <View style={styles.scroll}>
+                <CommunityProfileEventCardHorizontalScroll
+                  events={pastEvents}
+                  interestedIDs={interestedEventDocIds}
+                  onPress={this._onPressOpenEventPage}
+                  goingIDs={goingEventDocIds}
+                  status={'past'}
+                  source={'profile'}
+                />
+              </View>
             </View>
             <View style={styles.facepileContainer}>
+              <Text style={styles.sectionTitle}>volunteer network</Text>
               {this.state.volunteerNetwork !== [] && (
                 <Facepile
                   totalWidth={335}
@@ -350,6 +349,21 @@ const styles = StyleSheet.create({
   },
   profileBar: {
     flexDirection: 'row',
+    marginTop: 10,
+    backgroundColor: 'white',
+    width: Dimensions.get('window').width,
+    borderLeftWidth: 0,
+
+    shadowColor: 'black',
+    shadowOffset: {
+      width: 0,
+      height: 1,
+    },
+    shadowOpacity: 0.18,
+    shadowRadius: 1.0,
+    elevation: 1,
+    paddingHorizontal: SIDE_MARGIN,
+    paddingBottom: 5,
   },
   editIcon: {
     marginLeft: 35,
@@ -357,12 +371,9 @@ const styles = StyleSheet.create({
   },
   sectionTitle: {
     fontSize: 20,
-    fontFamily: 'raleway',
-  },
-  helpedTitle: {
-    fontSize: 20,
-    fontFamily: 'raleway',
-    marginBottom: 8,
+    fontFamily: 'raleway-medium',
+    marginBottom: 10,
+    marginTop: 20,
   },
   profilePic: {
     width: 78,
@@ -391,11 +402,12 @@ const styles = StyleSheet.create({
   comingUpBar: {
     height: 200,
   },
-  upcomingScroll: {
+  scroll: {
     marginTop: 8,
   },
   helpedBar: {
     height: 160,
+    marginTop: 20,
   },
   placeholder: {
     width: 335,
@@ -405,5 +417,8 @@ const styles = StyleSheet.create({
   },
   activityIndicator: {
     marginTop: 300,
+  },
+  facepileContainer: {
+    marginTop: 22,
   },
 });

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -318,7 +318,9 @@ export default class ProfileScreen extends React.Component {
               </View>
             </View>
             <View style={styles.facepileContainer}>
-              <Text style={styles.sectionTitle}>volunteer network</Text>
+              <Text style={[styles.sectionTitle, { marginBottom: 15 }]}>
+                volunteer network
+              </Text>
               {this.state.volunteerNetwork !== [] && (
                 <Facepile
                   totalWidth={335}
@@ -419,6 +421,6 @@ const styles = StyleSheet.create({
     marginTop: 300,
   },
   facepileContainer: {
-    marginTop: 22,
+    marginTop: 28,
   },
 });

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -274,7 +274,7 @@ export default class ProfileScreen extends React.Component {
               </View>
               <TouchableOpacity
                 onPress={this._onPressSettings}
-                style={styles.editIcon}
+                style={[styles.editIcon, { width: isCurrentUser ? 30 : 0 }]}
               >
                 <Ionicons name="ios-settings" size={30} color="#0081AF" />
               </TouchableOpacity>


### PR DESCRIPTION
Made it so that the settings button and ability to edit profile picture only appear if the profile is the current user's.
Fixes #142 
Fixes #143 

Also made UI changes to ProfileScreen which we'll have to anyway -- made the slight shadow border below the name and fixed spacing to match Figma. (First photo is if user has past events; second is if past events are empty). 

Next step is to edit what shows up if Facepile is empty (for EventScreen event attendees, CommunityScreen community members, and ProfileScreen volunteer network). Volunteer network section should probably just be empty if there's no one to show.

<img width="411" alt="Screen Shot 2019-05-24 at 11 39 44 AM" src="https://user-images.githubusercontent.com/32403070/58340666-5b72a400-7e1a-11e9-96a2-609f92db00d0.png">
<img width="404" alt="Screen Shot 2019-05-24 at 11 40 07 AM" src="https://user-images.githubusercontent.com/32403070/58340667-5b72a400-7e1a-11e9-8a6d-f409d6ee9ede.png">

Also made a tiny change to the event screen header -- text was slightly too close to logo before.