### PR TITLE
Empty Facepiles for EventScreen, CommunityScreen, ProfileScreen

### DIFF
--- a/volunta/components/CommunityProfileEventCard.js
+++ b/volunta/components/CommunityProfileEventCard.js
@@ -48,7 +48,7 @@ export default class CommunityProfileEventCard extends React.Component {
       var displayText = '';
       if (source == 'profile') {
         displayText =
-          'You currently have no upcoming events. Browse the Feed to join in!';
+          'You currently have no upcoming events. Browse the event feed to join in!';
       } else if (source == 'community') {
         displayText = 'Your community currently has no upcoming events.';
       }

--- a/volunta/components/Facepile.js
+++ b/volunta/components/Facepile.js
@@ -87,6 +87,9 @@ export default class Facepile extends React.Component {
   };
 
   render() {
+    if (this.props.members.length == 0) {
+      return null;
+    }
     return (
       <FlatList
         data={this.props.members.slice(0, this.props.maxNumImages)}

--- a/volunta/screens/CommunityScreen.js
+++ b/volunta/screens/CommunityScreen.js
@@ -120,9 +120,31 @@ export default class CommunityScreen extends React.Component {
       communityMembers,
     } = this.state;
     if (!refreshing) {
+      var facepileView = (
+        <Text style={styles.descriptionText}>
+          You're the first to join your community. Welcome!
+        </Text>
+      );
+      if (communityMembers.length > 0) {
+        facepileView = (
+          <View>
+            {this.state.communityMembers !== [] && (
+              <Facepile
+                totalWidth={335}
+                maxNumImages={10}
+                imageDiameter={50}
+                members={communityMembers}
+                pileTitle="Community Members"
+                navigation={this.props.navigation}
+              />
+            )}
+          </View>
+        );
+      }
+
       // Don't display past events if empty
       var pastEventDisplay = null;
-      var upcomingStyle = { left: 15 };
+      var upcomingStyle = {};
       const hidePastEvents = pastEvents.length == 0;
       if (!hidePastEvents) {
         pastEventDisplay = (
@@ -142,7 +164,7 @@ export default class CommunityScreen extends React.Component {
         );
       } else {
         // Remove spacing at the bottom when past events are empty
-        upcomingStyle = { left: 15, height: 0 };
+        upcomingStyle = { height: 0 };
       }
 
       return (
@@ -156,7 +178,7 @@ export default class CommunityScreen extends React.Component {
               />
             }
           >
-            <View style={[styles.screenContainer]}>
+            <View style={styles.screenContainer}>
               <CommunityCoverPhoto
                 communityPhoto={communityPhoto}
                 communityName={communityName}
@@ -169,22 +191,11 @@ export default class CommunityScreen extends React.Component {
               </View>
               <View style={styles.sectionContainer}>
                 <Text style={styles.titleText}>{'in my community'}</Text>
-                <View style={styles.facepileContainer}>
-                  {this.state.communityMembers !== [] && (
-                    <Facepile
-                      totalWidth={335}
-                      maxNumImages={10}
-                      imageDiameter={50}
-                      members={communityMembers}
-                      pileTitle="Community Members"
-                      navigation={this.props.navigation}
-                    />
-                  )}
-                </View>
+                {facepileView}
               </View>
               <View style={styles.sectionContainer}>
                 <Text style={styles.titleText}>{'coming up'}</Text>
-                <View style={upcomingStyle}>
+                <View>
                   <CommunityProfileEventCardHorizontalScroll
                     events={upcomingEvents}
                     onPress={this._onPressOpenEventPage}
@@ -213,33 +224,25 @@ export default class CommunityScreen extends React.Component {
 const styles = StyleSheet.create({
   screenContainer: {
     flex: 1,
-    paddingBottom: 22,
+    paddingBottom: 34,
   },
   sectionContainer: {
     top: -85,
     marginBottom: 17,
+    marginLeft: 19,
   },
   titleText: {
     fontFamily: 'raleway-medium',
     fontSize: 19,
     color: 'black',
-    left: 19,
     marginBottom: 8,
   },
   descriptionText: {
     fontFamily: 'raleway',
     fontSize: 14,
-    left: 20,
     color: '#444444',
   },
-  facepileContainer: {
-    left: 19,
-  },
-  upcomingScroll: {
-    left: 15,
-  },
   pastScroll: {
-    left: 15,
     height: 0, //removes extra blank space at bottom of scroll
   },
   activityIndicator: {

--- a/volunta/screens/CommunityScreen.js
+++ b/volunta/screens/CommunityScreen.js
@@ -195,7 +195,7 @@ export default class CommunityScreen extends React.Component {
               </View>
               <View style={styles.sectionContainer}>
                 <Text style={styles.titleText}>{'coming up'}</Text>
-                <View>
+                <View style={upcomingStyle}>
                   <CommunityProfileEventCardHorizontalScroll
                     events={upcomingEvents}
                     onPress={this._onPressOpenEventPage}

--- a/volunta/screens/EventScreen.js
+++ b/volunta/screens/EventScreen.js
@@ -247,7 +247,7 @@ export default class EventScreen extends React.Component {
             maxNumImages={10}
             imageDiameter={50}
             members={facePileAttendees}
-            pileTitle="Event Attendees"
+            pileTitle="Event Followers"
             navigation={this.props.navigation}
           />
           <Text style={[styles.detailText, styles.numGoingText]}>

--- a/volunta/screens/EventScreen.js
+++ b/volunta/screens/EventScreen.js
@@ -237,9 +237,7 @@ export default class EventScreen extends React.Component {
 
     // Render Facepile view only if there are users interested or going
     var facepileView = (
-      <Text style={[styles.detailText, styles.numGoingText]}>
-        Be the first to join the event!
-      </Text>
+      <Text style={styles.detailText}>Be the first to join the event!</Text>
     );
     if (numGoing > 0) {
       facepileView = (
@@ -290,12 +288,12 @@ export default class EventScreen extends React.Component {
           />
           <View style={styles.divider}>
             <View style={styles.facepileContainer}>
-              <Text style={styles.sectionText}>{"Who's going?"}</Text>
+              <Text style={styles.sectionText}>Who's going?</Text>
               {facepileView}
             </View>
           </View>
           <View style={styles.facepileContainer}>
-            <Text style={styles.sectionText}>{'Details'}</Text>
+            <Text style={styles.sectionText}>Details</Text>
             <Text style={styles.detailText}>{event.description}</Text>
           </View>
         </ScrollView>

--- a/volunta/screens/EventScreen.js
+++ b/volunta/screens/EventScreen.js
@@ -236,8 +236,11 @@ export default class EventScreen extends React.Component {
     }
 
     // Render Facepile view only if there are users interested or going
+    const emptyFacepileText = going
+      ? "You're the first to join this event!"
+      : 'Be the first to join the event!';
     var facepileView = (
-      <Text style={styles.detailText}>Be the first to join the event!</Text>
+      <Text style={styles.detailText}>{emptyFacepileText}</Text>
     );
     if (numGoing > 0) {
       facepileView = (

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -379,7 +379,7 @@ const styles = StyleSheet.create({
   sectionTitle: {
     fontSize: 20,
     fontFamily: 'raleway-medium',
-    marginBottom: 10,
+    marginBottom: 8,
     marginTop: 20,
   },
   profilePic: {

--- a/volunta/screens/ProfileScreen.js
+++ b/volunta/screens/ProfileScreen.js
@@ -242,8 +242,15 @@ export default class ProfileScreen extends React.Component {
       profilePic,
       profilePicIsBase64,
       isCurrentUser,
+      volunteerNetwork,
+      profileName,
+      communityName,
     } = this.state;
+
     const hidePastEvents = pastEvents.length == 0;
+
+    const volunteerNetworkDisplay =
+      volunteerNetwork.length == 0 ? { height: 0 } : {};
 
     if (!refreshing) {
       let img_uri = profilePicIsBase64
@@ -267,10 +274,8 @@ export default class ProfileScreen extends React.Component {
               <Image style={styles.profilePic} source={{ uri: img_uri }} />
             </TouchableOpacity>
             <View style={styles.upperText}>
-              <Text style={styles.personName}>{this.state.profileName}</Text>
-              <Text style={styles.communityName}>
-                {this.state.communityName}
-              </Text>
+              <Text style={styles.personName}>{profileName}</Text>
+              <Text style={styles.communityName}>{communityName}</Text>
             </View>
             <TouchableOpacity
               onPress={this._onPressSettings}
@@ -317,7 +322,7 @@ export default class ProfileScreen extends React.Component {
                 />
               </View>
             </View>
-            <View style={styles.facepileContainer}>
+            <View style={[styles.facepileContainer, volunteerNetworkDisplay]}>
               <Text style={[styles.sectionTitle, { marginBottom: 15 }]}>
                 volunteer network
               </Text>
@@ -327,7 +332,7 @@ export default class ProfileScreen extends React.Component {
                   maxNumImages={10}
                   imageDiameter={50}
                   navigation={this.props.navigation}
-                  members={this.state.volunteerNetwork}
+                  members={volunteerNetwork}
                   pileTitle="Volunteer Network"
                 />
               )}


### PR DESCRIPTION
Handled empty Facepiles for the three relevant screens and added the logic inside the screens themselves since it was pretty dependent on the use case and not on the component.
- EventScreen: displays "Be the first to join the event" if user isn't going and "You're the first to join this event!" if user is going
- CommunityScreen: displays "You're the first to join your community!"
- ProfileScreen: remove volunteer network section if user has no one in their volunteer network because it would probably confuse them otherwise

Fixes #125 

<img width="403" alt="Screen Shot 2019-05-28 at 7 15 43 PM" src="https://user-images.githubusercontent.com/32403070/58526444-d7a31980-8183-11e9-907d-dcf68cccc71b.png">

<img width="414" alt="Screen Shot 2019-05-28 at 7 46 27 PM" src="https://user-images.githubusercontent.com/32403070/58526443-d7a31980-8183-11e9-99cc-d306df8684ad.png">

<img width="412" alt="Screen Shot 2019-05-28 at 7 29 03 PM" src="https://user-images.githubusercontent.com/32403070/58526442-d7a31980-8183-11e9-9293-b4dbf5b01f73.png">